### PR TITLE
docs - Upload of Dockerfile and Doc about cross-compile stubs

### DIFF
--- a/src/cross-compiler/protobuf_gRPC_crosscompiling/Dockerfile
+++ b/src/cross-compiler/protobuf_gRPC_crosscompiling/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PROTOBUF_TAG=v25.8
+ARG GRPC_TAG=v1.60.1
+
+# ---- Install dependencies ----
+RUN apt-get update && apt-get install -y \
+    build-essential cmake git pkg-config \
+    autoconf libtool \
+    zlib1g-dev libc-ares-dev \
+    libssl-dev wget unzip python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Build & install Protobuf v25.8 ----
+RUN git clone --depth 1 --branch ${PROTOBUF_TAG} https://github.com/protocolbuffers/protobuf.git /tmp/protobuf \
+ && git clone --depth 1 --branch 20230802.0 https://github.com/abseil/abseil-cpp.git /tmp/protobuf/third_party/abseil-cpp \
+ && cmake -S /tmp/protobuf -B /tmp/protobuf/build \
+      -Dprotobuf_BUILD_TESTS=OFF \
+ && cmake --build /tmp/protobuf/build -j1 \
+ && cmake --install /tmp/protobuf/build \
+ && ldconfig \
+ && rm -rf /tmp/protobuf
+
+# ---- Build ONLY grpc_cpp_plugin from gRPC 1.60.1 ----
+RUN git clone --depth 1 --branch ${GRPC_TAG} https://github.com/grpc/grpc.git /tmp/grpc \
+ && git -C /tmp/grpc submodule update --init --recursive \
+ && cmake -S /tmp/grpc -B /tmp/grpc/build \
+      -DgRPC_BUILD_TESTS=OFF \
+      -DgRPC_INSTALL=OFF \
+      -DgRPC_BUILD_GRPC_CPP_PLUGIN=ON \
+      -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+      -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+      -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+      -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+      -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+      -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
+      -DgRPC_PROTOBUF_PROVIDER=package \
+ && cmake --build /tmp/grpc/build -j1 \
+ && cp /tmp/grpc/build/grpc_cpp_plugin /usr/local/bin/ \
+ && rm -rf /tmp/grpc
+
+# ---- Set working directory ----
+WORKDIR /work
+

--- a/src/cross-compiler/protobuf_gRPC_crosscompiling/README.md
+++ b/src/cross-compiler/protobuf_gRPC_crosscompiling/README.md
@@ -1,0 +1,170 @@
+# Protobuf & gRPC Stub Generation (Cross-Compilation Guide)
+
+This document explains **how and why** we generated the `*.pb.*` and `*.grpc.pb.*` files used by the KUKSA integration, and why this step is done **outside** the AGL target using a **cross-compilation / host environment**.
+
+---
+
+## Index
+
+1. [Why Stub Generation Is Needed](#why-stub-generation-is-needed)
+2. [Why This Is Done Outside the AGL Target](#why-this-is-done-outside-the-agl-target)
+3. [Version Compatibility (Important)](#version-compatibility-important)
+4. [Host Environment Setup (Docker)](#host-environment-setup-docker)
+   - [Docker Image Requirements](#docker-image-requirements)
+   - [How to do it](#how-to-do-it)
+
+---
+
+## Why Stub Generation Is Needed
+
+KUKSA Databroker exposes its API using **gRPC** and **Protocol Buffers**.
+
+To interact with it from C++, we must generate C++ source files from the `.proto` definitions:
+
+- `val.proto` – defines the VAL gRPC service (PublishValue, GetValue, etc.)
+- `types.proto` – defines shared data structures (SignalID, Datapoint, Value, …)
+- These files are in the `kuksa/proto`: `https://github.com/eclipse-kuksa/kuksa-databroker/tree/main/proto/kuksa/val/v2`
+
+These files are transformed into:
+- `*.pb.h / *.pb.cc` → Protobuf message types
+- `*.grpc.pb.h / *.grpc.pb.cc` → gRPC service stubs
+
+These generated files are then **compiled normally** on the AGL target as part of our application.
+
+---
+
+## What Are gRPC Stubs (Important Concept)
+
+KUKSA Databroker exposes its functionality as a **remote API** defined in `.proto` files.
+
+From these `.proto` files, **gRPC stubs** are generated and used by client applications (like our publisher and reader).
+
+### What is a Stub
+
+A **stub** is an **auto-generated, strongly-typed client API** that allows a C++ application to call a **remote service** as if it were a local function.
+
+In practical terms:
+- The stub represents the **KUKSA Databroker API**
+- Each stub method corresponds to a **remote API call**
+- Calling a stub method sends a request to the databroker over **gRPC**
+- All networking, serialization, and transport details are handled automatically
+
+Example:
+```cpp
+stub->PublishValue(&ctx, request, &response);
+```
+
+Although this looks like a normal C++ function call, internally it:
+
+- Serializes the request using Protocol Buffers
+- Sends it over HTTP/2 via gRPC
+- Waits for the remote response
+- Deserializes the response
+- Returns a gRPC status
+
+---
+
+## Why This Is Done Outside the AGL Target
+
+The AGL target **does not ship `protoc`** (the Protocol Buffer compiler), even though it provides:
+- `libprotobuf`
+- `libgrpc`
+- `libgrpc++`
+
+Therefore:
+- **Stub generation must happen on the host**
+- The generated `.cc/.h` files are architecture-independent
+- Only the compilation step must match the target architecture
+
+---
+
+## Version Compatibility (Important)
+**This was the main reason we need Docker**
+
+To avoid ABI / API mismatches:
+
+- `protoc` version must be **compatible with target libprotobuf**
+- `grpc_cpp_plugin` version must be **compatible with target libgrpc++**
+
+In our case:
+- AGL Databroker uses gRPC **1.60.1**
+- Protobuf runtime version is **25.x**
+
+So the host environment was aligned to these versions before generating stubs.
+
+---
+
+## Host Environment Setup (Docker)
+
+### Docker Image Requirements
+
+- `protoc` (matching protobuf version)
+- `grpc_cpp_plugin` (matching gRPC version)
+- `protobuf-dev`
+- `grpc-dev`
+
+This container is used **only** to generate source files.
+
+---
+
+## How to do it?
+
+We use a Docker container **only** to generate stubs.
+
+The Dockerfile used is in `/src/cross-compiler/proto-stubs-kuksa`.
+
+### Run Docker build
+
+#### 1. Build the image (from the folder that contains the Dockerfile)
+`docker build -t kuksa-proto-gen .`
+
+#### 2. Run an interactive shell with your current folder mounted into /work
+```
+docker run --rm -it \
+  -v "$(pwd)":/work \
+  kuksa-proto-gen \
+  bash
+```
+This:
+- Starts a container from that image
+- Mounts your project folder into the container at /work
+
+#### 3. Inside the container generate the files
+
+Correct the path of `val.proto` and `types.proto` if needed.
+```
+cd /work
+
+mkdir -p generated
+
+protoc -I proto \
+  --cpp_out=generated \
+  proto/types.proto \
+  proto/val.proto
+
+protoc -I proto \
+  --grpc_out=generated \
+  --plugin=protoc-gen-grpc="$(which grpc_cpp_plugin)" \
+  proto/types.proto \
+  proto/val.proto
+
+```
+  This generates:
+
+  ```
+generated/
+└── kuksa/val/v2/
+    ├── types.pb.h
+    ├── types.pb.cc
+    ├── types.grpc.pb.h
+    ├── types.grpc.pb.cc
+    ├── val.pb.h
+    ├── val.pb.cc
+    ├── val.grpc.pb.h
+    └── val.grpc.pb.cc
+````
+
+Now these files can be tranfered to AGL.
+
+When compiling the KUKSA publisher the files are compiled together with the application.
+


### PR DESCRIPTION
## 🧾 Summary
Explain what this PR does and why it’s needed:
This PR adds a Docker-based, reproducible environment to generate **Protobuf + gRPC C++ stubs** (`*.pb.*` and `*.grpc.pb.*`) for the KUKSA VAL v2 API (`val.proto`, `types.proto`).

- [x] New Feature
- [ ] Bug Fix
- [x] Docs
- [ ] Refactor / Cleanup
- [ ] CI/CD

## 🔗 Related
Relates to #107, #108

## 🧪 Testing
How did you test it? Steps for reviewers to verify.

- [ ] Unit tests
- [ ] Hardware on PiRacer
- [x] Manual verification

**Steps to test:**
1. Build the image - `docker build -t kuksa-proto-gen .`
2. Run an interactive shell - command on the README.md file
3. Generate the files inside the container - commands on the README.md file
4. Verify the creation of all `*.pb.*` and `*.grpc.pb.*` files

## 🧱 TSF Traceability
List requirements impacted/satisfied.

| Requirement ID | Description | Status |
|---|---|---|
| EXPECT-L0-8 | Use CAN protocol to connect the Rasp5 to the STM 32(bidirectional) | ⚙️ In Progress  |

## ✅ Checklist
- [ ] Lints pass
- [ ] Tests pass
- [x] Docs updated (if needed)
- [x] Linked to issue/epic

