### PR TITLE
fix - Fixed the speed conversion in the speed handler and VSS

### DIFF
--- a/src/kuksa/kuksa_RPi5/src/handlers/speed.cpp
+++ b/src/kuksa/kuksa_RPi5/src/handlers/speed.cpp
@@ -20,12 +20,14 @@ void handleWheelSpeed(const can_frame& frame, IKuksaClient& kuksa)
     const std::uint32_t pulses    = can_decode::u32_le(&frame.data[2]);   // bytes 2-5 (optional here)
     const std::uint8_t  direction = can_decode::u8(&frame.data[6]);       // byte 6
     const std::uint8_t  status    = can_decode::u8(&frame.data[7]);       // byte 7
-    (void)pulses; (void)direction; (void)status;
+    (void)direction; (void)status;
+
+    const std::int16_t rpm = can_decode::i16_le(&frame.data[0]);
 
     double rpm_signed = static_cast<double>(rpm);
     const double rps = rpm_signed / 60.0;
-    const double speed_ms  = rps * WHEEL_PERIMETER;  // wheel_perimeter in meters
-    const double speed_kmh = speed_ms * 3.6;
+    const double speed_mh  = (rps * WHEEL_PERIMETER) * 1000.0 * 3.6;
+    const double speed_kmh = speed_mh * 3.6;
 
-    kuksa.publishDouble(sig::VEHICLE_SPEED, speed_ms);
+    kuksa.publishDouble(sig::VEHICLE_SPEED, speed_mh);
 }

--- a/src/kuksa/kuksa_RPi5/vss_min.json
+++ b/src/kuksa/kuksa_RPi5/vss_min.json
@@ -62,7 +62,7 @@
         "datatype": "double",
         "description": "Vehicle speed measured by Hall effect sensor.",
         "type": "sensor",
-        "unit": "km/h",
+        "unit": "m/h",
         "min": 0,
         "comment": "Hall effect speed sensor via STM32 B-U585I-IOT02A"
       },


### PR DESCRIPTION
## 🧾 Summary
Explain what this PR does and why it’s needed:
This PR serves to fix a small error in the conversion of speed on the speed handler.

- [ ] New Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor / Cleanup
- [ ] CI/CD

## 🧪 Testing
How did you test it? Steps for reviewers to verify.

- [ ] Unit tests
- [ ] Hardware on PiRacer
- [x] Manual verification

**Steps to test:**
1. Run the kuksa_publisher in AGL and the kuksa_reader in the display (RPi4)
2. Verify that the speed displayed in the reader is the same than the speed in the stm's LCD

