### PR TITLE
Feature/can simulation

### DIFF
--- a/src/kuksa/kuksa_RPi5/src/can_simulator/CAN emulator.md
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/CAN emulator.md
@@ -1,3 +1,5 @@
+# Can simulator
+
 > Create a CAN emulator that can replicate STM32's frame sending
 > This is done to test the UI without having to manually drive the car
 
@@ -10,7 +12,8 @@ Flow:
 ## How to setup
 
 ### 1️⃣ Build the emulator
-`g++ -std=c++17 -O2 can_emulator.cpp -o can_emulator -lpthread`
+`cmake -S . -B build`
+`cmake --build build`
 
 ### 2️⃣ Create and enable `vcan0`
 `sudo modprobe vcan`
@@ -22,7 +25,7 @@ Flow:
 `candump vcan0`
 
 #### ⓸ Run the emulator
-`./can_emulator vcan0 ./scenarios`
+`./can_emulator`
 
 ### 5️⃣ Run the can_to_kuksa_publisher with vcan0
 `./home/kuksa_RPi5/bin/can_to_kuksa_publisher vcan0`

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/CAN emulator.md
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/CAN emulator.md
@@ -1,0 +1,40 @@
+> Create a CAN emulator that can replicate STM32's frame sending
+> This is done to test the UI without having to manually drive the car
+
+Flow:
+- Open `vcan0`
+- Read a scenario file
+- Periodically send CAN frames
+- Simulate realistic timing
+
+## How to setup
+
+### 1️⃣ Build the emulator
+`g++ -std=c++17 -O2 can_emulator.cpp -o can_emulator -lpthread`
+
+### 2️⃣ Create and enable `vcan0`
+`sudo modprobe vcan`
+`sudo ip link add dev vcan0 type vcan`
+`sudo ip link set up vcan0`
+`ip link show vcan0`
+
+### 3️⃣ Test that CAN works
+`candump vcan0`
+
+#### ⓸ Run the emulator
+`./can_emulator vcan0 ./scenarios`
+
+### 5️⃣ Run the can_to_kuksa_publisher with vcan0
+`./home/kuksa_RPi5/bin/can_to_kuksa_publisher vcan0`
+
+In this case we can't use the can_to_kuksa service that is running on AGL because it is hardcoded to can1 channel.
+So we run the binary and specify the channel - `vcan0`
+
+### ⓻ Check if it is working with kuksa-client
+`kuksa-client --cacertificate /etc/kuksa/tls/ca.crt --token_or_tokenfile /etc/kuksa/jwt/publisher.jwt grpcs://10.21.220.191:55555`
+
+Then:
+`getValue Vehicle.Speed` 
+
+Or:
+`Run Qt and see the changes in the cluster`

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/CMakeLists.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.16)
+project(can_emulator LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(can_emulator
+  src/main.cpp
+  src/can_sender.cpp
+  src/helpers.cpp
+  src/scenario_loader.cpp
+  src/frames_builder.cpp
+  src/cli.cpp
+)
+
+target_include_directories(can_emulator PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/inc
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../inc
+)
+
+find_package(Threads REQUIRED)
+target_link_libraries(can_emulator PRIVATE Threads::Threads)
+
+target_compile_options(can_emulator PRIVATE -Wall -Wextra -Wpedantic)

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/can_emulator.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/can_emulator.cpp
@@ -32,13 +32,10 @@
 #endif
 
 #include "../../inc/can_id.h"
+#include "inc/helpers.hpp"
+#include "inc/sim_state.hpp"
+#include "inc/app_context.hpp"
 
-static std::atomic<bool> g_tx_enabled(true);
-
-// -----------------------------
-// CRC8 (poly 0x07, init 0x00)
-// NOTE: If STM32 uses a different CRC8, align this function.
-// -----------------------------
 static uint8_t crc8(const uint8_t* data, size_t len)
 {
   uint8_t crc = 0x00;
@@ -103,6 +100,7 @@ static bool send_payload8(int sock, uint32_t can_id, const void* payload8)
 // -----------------------------
 // Sim state (latest values)
 // -----------------------------
+/*
 struct SimState {
   // Heartbeat
   uint8_t hb_state  = SYSTEM_STATE_RUNNING;
@@ -155,7 +153,7 @@ struct SimState {
   uint16_t motor_current_ma = 0;
   int8_t   motor_driver_temp = 30;
   uint8_t  motor_pwm = 0;
-};
+};*/
 
 static int16_t clamp_i16(long v) {
   if (v > 32767) return 32767;
@@ -167,22 +165,6 @@ static uint8_t clamp_u8(long v) {
   if (v > 255) return 255;
   return static_cast<uint8_t>(v);
 }
-
-// -----------------------------
-// Scenario model
-// -----------------------------
-struct Event {
-  uint32_t t_ms = 0;
-  std::vector<std::pair<std::string,std::string>> kv;
-};
-
-struct Scenario {
-  std::string name;   // filename
-  std::string path;   // full path
-  std::vector<std::pair<std::string,std::string>> init_kv;
-  std::vector<Event> events;
-  uint32_t duration_ms = 0;
-};
 
 static std::string trim(const std::string& s)
 {
@@ -508,6 +490,7 @@ static uint64_t now_ms()
 // -----------------------------
 // Global shared state
 // -----------------------------
+/*
 static std::mutex g_state_mtx;
 static SimState g_state;
 static const SimState g_defaults; // value-initialized defaults
@@ -524,88 +507,82 @@ static std::mutex g_play_mtx;
 static Playback g_play;
 static std::vector<Scenario> g_scenarios;
 static std::string g_scenario_dir;
-
-static std::atomic<bool> g_running(true);
+*/
 
 // Apply init + any t=0 events to current state (caller holds g_state_mtx)
-static void apply_scenario_start_locked(const Scenario& sc)
+static void apply_scenario_start_locked(AppContext& ctx, const Scenario& sc)
 {
-  g_state = g_defaults;
-  for (const auto& kv : sc.init_kv) apply_kv(g_state, kv.first, kv.second);
+
+  ctx.state = ctx.defaults;
+  for (const auto& kv : sc.init_kv) apply_kv(ctx.state, kv.first, kv.second);
   // Apply t=0 events
   for (const auto& ev : sc.events) {
     if (ev.t_ms != 0) break;
-    for (const auto& kv : ev.kv) apply_kv(g_state, kv.first, kv.second);
+    for (const auto& kv : ev.kv) apply_kv(ctx.state, kv.first, kv.second);
   }
 }
 
 // -----------------------------
 // Scenario player thread
 // -----------------------------
-static void scenario_player_loop()
+static void scenario_player_loop(AppContext& ctx)
 {
-  while (g_running.load()) {
-    Scenario sc;
+  while (ctx.running.load()) {
     Playback pb;
 
     {
-      std::lock_guard<std::mutex> lk(g_play_mtx);
-      pb = g_play;
-      if (!pb.playing || g_scenarios.empty() || pb.scenario_index >= g_scenarios.size()) {
-        // idle
-        // (keep last state; do not reset)
-        // Sleep small and retry
-        //
-        // Note: we copy pb above so we can avoid holding mutex while sleeping
-      }
+      std::lock_guard<std::mutex> lk(ctx.play_mtx);
+      pb = ctx.play;
     }
 
-    if (!pb.playing || g_scenarios.empty() || pb.scenario_index >= g_scenarios.size()) {
+    // Check if we should be playing
+    // If not, sleep a bit and check again
+    if (!pb.playing || ctx.scenarios.empty() || pb.scenario_index >= ctx.scenarios.size()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
       continue;
     }
 
-    sc = g_scenarios[pb.scenario_index];
+    // Playing a scenario, get it
+    const Scenario& sc = ctx.scenarios[pb.scenario_index];
 
     const uint64_t now = now_ms();
     const uint32_t elapsed = static_cast<uint32_t>(now - pb.start_ms);
 
-    // Apply due events
+    // Apply due events to ctx.state (under lock)
     bool reached_end = false;
     {
-      std::lock_guard<std::mutex> lk_state(g_state_mtx);
+      std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
 
       size_t i = pb.next_event_idx;
       while (i < sc.events.size() && sc.events[i].t_ms <= elapsed) {
-        for (const auto& kv : sc.events[i].kv) apply_kv(g_state, kv.first, kv.second);
+        for (const auto& kv : sc.events[i].kv) apply_kv(ctx.state, kv.first, kv.second);
         i++;
       }
-
+      reached_end = (i >= sc.events.size());
       // write back next_event_idx
       {
-        std::lock_guard<std::mutex> lk_play(g_play_mtx);
+        std::lock_guard<std::mutex> lk_play(ctx.play_mtx);
         // scenario might have changed; only write if still same one and playing
-        if (g_play.playing && g_play.scenario_index == pb.scenario_index) {
-          g_play.next_event_idx = i;
+        if (ctx.play.playing && ctx.play.scenario_index == pb.scenario_index) {
+          ctx.play.next_event_idx = i;
         }
       }
-
-      reached_end = (i >= sc.events.size());
     }
 
+    // handle end of scenario
     if (reached_end) {
       const uint32_t GRACE_MS = 1000;
       if (elapsed >= sc.duration_ms + GRACE_MS) {
-        std::lock_guard<std::mutex> lk(g_play_mtx);
-        if (g_play.playing && g_play.scenario_index == pb.scenario_index) {
-          if (g_play.loop) {
-            g_play.start_ms = now_ms();
-            g_play.next_event_idx = 0;
+        std::lock_guard<std::mutex> lk(ctx.play_mtx);
+        if (ctx.play.playing && ctx.play.scenario_index == pb.scenario_index) {
+          if (ctx.play.loop) {
+            ctx.play.start_ms = now_ms();
+            ctx.play.next_event_idx = 0;
             // reset state to defaults + init
-            std::lock_guard<std::mutex> lk_state(g_state_mtx);
-            apply_scenario_start_locked(sc);
+            std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+            apply_scenario_start_locked(ctx, sc);
           } else {
-            g_play.playing = false;
+            ctx.play.playing = false;
           }
         }
       }
@@ -618,19 +595,8 @@ static void scenario_player_loop()
 // -----------------------------
 // CAN sender thread
 // -----------------------------
-struct Periods {
-  uint32_t motor = CAN_PERIOD_MOTOR_STATUS_MS;
-  uint32_t imu_fast = CAN_PERIOD_IMU_FAST_MS;
-  uint32_t imu_mag  = CAN_PERIOD_IMU_MAG_MS;
-  uint32_t wheel = CAN_PERIOD_WHEEL_SPEED_MS;
-  uint32_t tof = CAN_PERIOD_TOF_MS;
-  uint32_t env = CAN_PERIOD_ENVIRONMENT_MS;
-  uint32_t batt = CAN_PERIOD_BATTERY_MS;
-  uint32_t hb = CAN_PERIOD_HEARTBEAT_MS;
-  uint32_t estop = CAN_PERIOD_HEARTBEAT_MS; // default: same as heartbeat
-};
 
-static void can_sender_loop(int sock, Periods P)
+static void can_sender_loop(int sock, AppContext& ctx)
 {
   uint64_t t0 = now_ms();
 
@@ -646,21 +612,21 @@ static void can_sender_loop(int sock, Periods P)
 
   uint8_t motor_counter = 0;
 
-  while (g_running.load()) {
-
-    if (!g_tx_enabled.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-      continue;
-    }
+  while (ctx.running.load()) {
     const uint64_t now = now_ms();
     const uint32_t uptime = static_cast<uint32_t>(now - t0);
 
+    // snapshot the latest state (under lock)
     SimState st;
     {
-      std::lock_guard<std::mutex> lk(g_state_mtx);
-      st = g_state;
+      std::lock_guard<std::mutex> lk(ctx.play_mtx);
+      st = ctx.state;
     }
+    // snapshot the periods (no lock needed since they are const)
+    const Periods& P = ctx.periods;
 
+    // Send frames - check each one
+    // if the time passed is equal or greater than the scheduled
     if (now >= next_motor) {
       MotorStatus_t m = make_motor_status(st, motor_counter++);
       send_payload8(sock, CAN_ID_MOTOR_STATUS, &m);
@@ -741,20 +707,20 @@ static void print_help()
     "  quit\n";
 }
 
-static void cmd_list()
+static void cmd_list(AppContext& ctx)
 {
-  if (g_scenarios.empty()) {
+  if (ctx.scenarios.empty()) {
     std::cout << "(no scenarios loaded)\n";
     return;
   }
-  for (size_t i = 0; i < g_scenarios.size(); ++i) {
-    std::cout << i << ") " << g_scenarios[i].name
-              << "  (events=" << g_scenarios[i].events.size()
-              << ", duration=" << g_scenarios[i].duration_ms << "ms)\n";
+  for (size_t i = 0; i < ctx.scenarios.size(); ++i) {
+    std::cout << i << ") " << ctx.scenarios[i].name
+              << "  (events=" << ctx.scenarios[i].events.size()
+              << ", duration=" << ctx.scenarios[i].duration_ms << "ms)\n";
   }
 }
 
-static bool parse_index_or_name(const std::string& s, size_t& out_idx)
+static bool parse_index_or_name(AppContext& ctx, const std::string& s, size_t& out_idx)
 {
   // try integer
   char* end = nullptr;
@@ -766,84 +732,84 @@ static bool parse_index_or_name(const std::string& s, size_t& out_idx)
   }
 
   // try name match
-  for (size_t i = 0; i < g_scenarios.size(); ++i) {
-    if (g_scenarios[i].name == s) { out_idx = i; return true; }
+  for (size_t i = 0; i < ctx.scenarios.size(); ++i) {
+    if (ctx.scenarios[i].name == s) { out_idx = i; return true; }
   }
   return false;
 }
 
-static void cmd_play(const std::string& arg)
+static void cmd_play(const std::string& arg, AppContext& ctx)
 {
-  if (g_scenarios.empty()) {
+  if (ctx.scenarios.empty()) {
     std::cout << "No scenarios loaded. Use 'reload' or check the folder.\n";
     return;
   }
 
   size_t idx = 0;
-  if (!parse_index_or_name(arg, idx) || idx >= g_scenarios.size()) {
+  if (!parse_index_or_name(ctx, arg, idx) || idx >= ctx.scenarios.size()) {
     std::cout << "Unknown scenario: " << arg << "\n";
     return;
   }
 
-  const Scenario& sc = g_scenarios[idx];
+  const Scenario& sc = ctx.scenarios[idx];
 
   {
-    std::lock_guard<std::mutex> lk_state(g_state_mtx);
-    apply_scenario_start_locked(sc);
+    std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+    apply_scenario_start_locked(ctx, sc);
   }
 
   {
-    std::lock_guard<std::mutex> lk(g_play_mtx);
-    g_play.playing = true;
-    g_play.scenario_index = idx;
-    g_play.next_event_idx = 0;
-    g_play.start_ms = now_ms();
+    std::lock_guard<std::mutex> lk(ctx.play_mtx);
+    ctx.play.playing = true;
+    ctx.play.scenario_index = idx;
+    ctx.play.next_event_idx = 0;
+    ctx.play.start_ms = now_ms();
   }
 
-  std::cout << "[OK] Playing " << sc.name << " (loop=" << (g_play.loop ? "on" : "off") << ")\n";
+  std::cout << "[OK] Playing " << sc.name << " (loop=" << (ctx.play.loop ? "on" : "off") << ")\n";
 }
 
-static void cmd_stop()
+static void cmd_stop(AppContext& ctx)
 {
-  std::lock_guard<std::mutex> lk(g_play_mtx);
-  g_play.playing = false;
+  std::lock_guard<std::mutex> lk(ctx.play_mtx);
+  ctx.play.playing = false;
   std::cout << "[OK] Stopped\n";
 }
 
-static void cmd_loop(const std::string& arg)
+static void cmd_loop(const std::string& arg, AppContext& ctx)
 {
   bool on = (arg == "on" || arg == "1" || arg == "true");
   {
-    std::lock_guard<std::mutex> lk(g_play_mtx);
-    g_play.loop = on;
+    std::lock_guard<std::mutex> lk(ctx.play_mtx);
+    ctx.play.loop = on;
   }
   std::cout << "[OK] loop=" << (on ? "on" : "off") << "\n";
 }
 
-static void cmd_status()
+static void cmd_status(AppContext& ctx)
 {
   Playback pb;
   {
-    std::lock_guard<std::mutex> lk(g_play_mtx);
-    pb = g_play;
+    std::lock_guard<std::mutex> lk(ctx.play_mtx);
+    pb = ctx.play;
   }
 
   std::cout << "playing=" << (pb.playing ? "yes" : "no")
             << " loop=" << (pb.loop ? "on" : "off");
 
-  if (pb.playing && !g_scenarios.empty() && pb.scenario_index < g_scenarios.size()) {
-    std::cout << " scenario=" << g_scenarios[pb.scenario_index].name
+  if (pb.playing && !ctx.scenarios.empty() && pb.scenario_index < ctx.scenarios.size()) {
+    std::cout << " scenario=" << ctx.scenarios[pb.scenario_index].name
               << " next_event_idx=" << pb.next_event_idx;
   }
   std::cout << "\n";
 }
 
-static void cmd_show()
+static void cmd_show(AppContext& ctx)
 {
   SimState st;
   {
-    std::lock_guard<std::mutex> lk(g_state_mtx);
-    st = g_state;
+    std::lock_guard<std::mutex> lk(ctx.state_mtx);
+    st = ctx.state;
   }
 
   std::cout
@@ -866,72 +832,71 @@ static void cmd_show()
     << "\n";
 }
 
-static void cmd_reset()
+static void cmd_reset(AppContext& ctx)
 {
   {
-    std::lock_guard<std::mutex> lk_state(g_state_mtx);
-    g_state = g_defaults;
+    std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+    ctx.state = ctx.defaults;
   }
   std::cout << "[OK] State reset to defaults\n";
 }
 
-static void cmd_reload()
+static void cmd_reload(AppContext& ctx)
 {
   try {
-    g_scenarios = load_scenarios_dir(g_scenario_dir);
-    std::cout << "[OK] Reloaded scenarios (" << g_scenarios.size() << ") from " << g_scenario_dir << "\n";
+    ctx.scenarios = load_scenarios_dir(ctx.scenario_dir);
+    std::cout << "[OK] Reloaded scenarios (" << ctx.scenarios.size() << ") from " << ctx.scenario_dir << "\n";
   } catch (const std::exception& e) {
     std::cout << "[ERR] " << e.what() << "\n";
   }
 }
 
-static void cli_loop()
+static void cli_loop(AppContext& ctx)
 {
   print_help();
   std::string line;
 
-  while (g_running.load()) {
+  // Main CLI loop
+  while (ctx.running.load()) {
+    // Prompt
     std::cout << "emu> " << std::flush;
+    // Read line
     if (!std::getline(std::cin, line)) {
-      g_running.store(false);
+      ctx.running.store(false);
       break;
     }
 
+    // Trim and skip empty
     line = trim(line);
     if (line.empty()) continue;
 
+    // Parse command
     std::istringstream iss(line);
     std::string cmd;
     iss >> cmd;
 
+    // Handle commands
     if (cmd == "help") print_help();
-    else if (cmd == "list") cmd_list();
+    else if (cmd == "list") cmd_list(ctx);
     else if (cmd == "play") {
       std::string arg; iss >> arg;
       if (arg.empty()) {
         std::cout << "usage: play <index|name>\n";
-        g_tx_enabled.store(true);
       }
-      else cmd_play(arg);
+      else cmd_play(arg, ctx);
     }
-    else if (cmd == "stop") cmd_stop();
+    else if (cmd == "stop") cmd_stop(ctx);
     else if (cmd == "loop") {
       std::string arg; iss >> arg;
       if (arg.empty()) std::cout << "usage: loop on|off\n";
-      else cmd_loop(arg);
+      else cmd_loop(arg, ctx);
     }
-    else if (cmd == "status") cmd_status();
-    else if (cmd == "show") cmd_show();
-    else if (cmd == "reset") cmd_reset();
-    else if (cmd == "reload") cmd_reload();
-    else if (cmd == "tx") {
-      std::string arg; iss >> arg;
-      if (arg == "on") {g_tx_enabled.store(true); std::cout << "[OK] tx=on\n";}
-      else if (arg == "off") { g_tx_enabled.store(false); std::cout << "[OK] tx=off\n"; }
-      else std::cout << "usage: tx on|off\n";
-    }
+    else if (cmd == "status") cmd_status(ctx);
+    else if (cmd == "show") cmd_show(ctx);
+    else if (cmd == "reset") cmd_reset(ctx);
+    else if (cmd == "reload") cmd_reload(ctx);
     else if (cmd == "quit" || cmd == "exit") {
-      g_running.store(false);
+      ctx.running.store(false);
       break;
     }
     else {
@@ -949,8 +914,74 @@ static void usage(const char* prog)
 
 int main(int argc, char** argv)
 {
-  if (argc < 3) { usage(argv[0]); return 1; }
+  if (argc != 1) {
+    usage(argv[0]);
+    return 1;
+  }
 
+  const std::string iface = "vcan0"; // default interface
+
+  AppContext ctx; // create context to hold shared state and config
+
+  // hardcoded scenario directory
+  ctx.scenario_dir = "./scenarios";
+
+  // load scenarios (fail if folder missing)
+  try {
+    ctx.scenarios = load_scenarios_dir(ctx.scenario_dir);
+  } catch (const std::exception& e) {
+    std::cerr << "[EMU] " << e.what() << "\n";
+    return 1;
+  }
+  if (ctx.scenarios.empty()) {
+    std::cerr << "[EMU] No scenarios found in: " << ctx.scenario_dir << "\n";
+    return 1;
+  }
+
+  std::cout << "[EMU] Loaded " << ctx.scenarios.size()
+            << " scenario(s) from " << ctx.scenario_dir << "\n";
+
+  std::cout << "[EMU] IDs (from can_id.h): wheel=0x" << std::hex << CAN_ID_WHEEL_SPEED
+            << " imu_acc=0x" << CAN_ID_IMU_ACCEL
+            << " imu_gyro=0x" << CAN_ID_IMU_GYRO
+            << " imu_mag=0x" << CAN_ID_IMU_MAG
+            << " env=0x" << CAN_ID_ENVIRONMENT
+            << " batt=0x" << CAN_ID_BATTERY
+            << " tof=0x" << CAN_ID_TOF_DISTANCE
+            << " hb=0x" << CAN_ID_HEARTBEAT_STM32
+            << " estop=0x" << CAN_ID_EMERGENCY_STOP
+            << " motor_status=0x" << CAN_ID_MOTOR_STATUS
+            << std::dec << "\n";
+
+  const int sock = open_can_tx_socket(iface);
+  if (sock < 0) return 1;
+
+  // Threads (IMPORTANT: pass ctx by reference using std::ref)
+  std::thread t_player(scenario_player_loop, std::ref(ctx));
+  std::thread t_sender(can_sender_loop, sock, std::ref(ctx));
+
+  // Main thread = CLI
+  cli_loop(ctx);
+
+  // Shutdown
+  ctx.running.store(false);
+  if (t_player.joinable()) t_player.join();
+  if (t_sender.joinable()) t_sender.join();
+
+  ::close(sock);
+  std::cout << "[EMU] Bye.\n";
+  return 0;
+}
+
+/*
+int main(int argc, char** argv)
+{
+  AppContext ctx;
+  if (argc < 3) { usage(argv[0]); return 1; } // (required args: iface, scenario_dir)
+
+  ctx.scenario_dir = argv[2]; // give the scenario dir to the CLI
+
+  ctx.iface = argv[1];
   const std::string iface = argv[1];
   g_scenario_dir = argv[2];
 
@@ -958,22 +989,6 @@ int main(int argc, char** argv)
   auto parse_u32 = [](const std::string& s)->uint32_t {
     return static_cast<uint32_t>(std::strtoul(s.c_str(), nullptr, 10));
   };
-
-  for (int i = 3; i < argc; ++i) {
-    std::string a = argv[i];
-    if (a.rfind("--p-motor=",0)==0) P.motor = parse_u32(a.substr(10));
-    else if (a.rfind("--p-imu=",0)==0)   P.imu_fast = parse_u32(a.substr(8));
-    else if (a.rfind("--p-mag=",0)==0)   P.imu_mag  = parse_u32(a.substr(8));
-    else if (a.rfind("--p-wheel=",0)==0) P.wheel = parse_u32(a.substr(10));
-    else if (a.rfind("--p-tof=",0)==0)   P.tof   = parse_u32(a.substr(8));
-    else if (a.rfind("--p-env=",0)==0)   P.env   = parse_u32(a.substr(8));
-    else if (a.rfind("--p-batt=",0)==0)  P.batt  = parse_u32(a.substr(9));
-    else if (a.rfind("--p-hb=",0)==0)    P.hb    = parse_u32(a.substr(7));
-    else if (a.rfind("--p-estop=",0)==0) P.estop = parse_u32(a.substr(10));
-    else {
-      std::cerr << "[EMU] Unknown arg: " << a << "\n";
-    }
-  }
 
   try {
     g_scenarios = load_scenarios_dir(g_scenario_dir);
@@ -999,7 +1014,7 @@ int main(int argc, char** argv)
   if (sock < 0) return 1;
 
   // threads
-  std::thread t_player(scenario_player_loop);
+  std::thread t_player(scenario_player_loop, ctx);
   std::thread t_sender(can_sender_loop, sock, P);
 
   // main thread = CLI
@@ -1014,3 +1029,4 @@ int main(int argc, char** argv)
   std::cout << "[EMU] Bye.\n";
   return 0;
 }
+*/

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/can_emulator.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/can_emulator.cpp
@@ -1,0 +1,1016 @@
+// tools/can_sim/can_emulator.cpp
+//
+// Interactive CAN-only emulator that mimics STM32 publishing on SocketCAN.
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <chrono>
+#include <thread>
+#include <cmath>
+#include <mutex>
+#include <atomic>
+
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#else
+  #error "C++17 <filesystem> required"
+#endif
+
+#include "../../inc/can_id.h"
+
+static std::atomic<bool> g_tx_enabled(true);
+
+// -----------------------------
+// CRC8 (poly 0x07, init 0x00)
+// NOTE: If STM32 uses a different CRC8, align this function.
+// -----------------------------
+static uint8_t crc8(const uint8_t* data, size_t len)
+{
+  uint8_t crc = 0x00;
+  for (size_t i = 0; i < len; ++i) {
+    crc ^= data[i];
+    for (int b = 0; b < 8; ++b) {
+      if (crc & 0x80) crc = static_cast<uint8_t>((crc << 1) ^ 0x07);
+      else           crc = static_cast<uint8_t>(crc << 1);
+    }
+  }
+  return crc;
+}
+
+// -----------------------------
+// SocketCAN helpers
+// -----------------------------
+static int open_can_tx_socket(const std::string& ifname)
+{
+  int s = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+  if (s < 0) {
+    std::cerr << "[EMU] socket() failed: " << std::strerror(errno) << "\n";
+    return -1;
+  }
+
+  ifreq ifr{};
+  std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
+
+  if (::ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
+    std::cerr << "[EMU] ioctl(SIOCGIFINDEX) failed: " << std::strerror(errno) << "\n";
+    ::close(s);
+    return -1;
+  }
+
+  sockaddr_can addr{};
+  addr.can_family  = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (::bind(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    std::cerr << "[EMU] bind() failed: " << std::strerror(errno) << "\n";
+    ::close(s);
+    return -1;
+  }
+
+  std::cout << "[EMU] Sending on interface: " << ifname << "\n";
+  return s;
+}
+
+static bool send_payload8(int sock, uint32_t can_id, const void* payload8)
+{
+  can_frame f{};
+  f.can_id  = can_id;
+  f.can_dlc = 8;
+  std::memcpy(f.data, payload8, 8);
+  const ssize_t n = ::write(sock, &f, sizeof(f));
+  if (n != static_cast<ssize_t>(sizeof(f))) {
+    std::cerr << "[EMU] write() failed/short: " << std::strerror(errno) << "\n";
+    return false;
+  }
+  return true;
+}
+
+// -----------------------------
+// Sim state (latest values)
+// -----------------------------
+struct SimState {
+  // Heartbeat
+  uint8_t hb_state  = SYSTEM_STATE_RUNNING;
+  uint8_t hb_errors = 0;
+  uint8_t hb_mode   = DRIVE_MODE_MANUAL;
+
+  // Emergency stop
+  uint8_t  estop_active = 0;
+  uint8_t  estop_source = 0; // 0=ToF, 1=AGL, 2=Manual, 3=Watchdog
+  uint16_t estop_mm     = 4000;
+  uint8_t  estop_reason = 0;
+
+  // Wheel speed
+  int16_t  rpm = 0;
+  uint32_t pulses = 0;
+  uint8_t  direction = 0;
+  uint8_t  wheel_status = 0;
+
+  // ToF
+  uint16_t tof_mm = 4000;
+  uint8_t  tof_zone = 255;
+  uint8_t  tof_target_status = 0;
+  uint8_t  tof_count = 0;
+  uint8_t  tof_status = 0;
+
+  // Environment (semantic)
+  float    env_temp_c = 21.5f;
+  float    env_humidity = 50.0f;
+  uint32_t env_light_lux = 800;
+  float    env_pressure_hpa = 1013.25f;
+  uint8_t  env_status = 0;
+
+  // Battery (raw)
+  uint16_t batt_mv = 12300;
+  int16_t  batt_ma = 0;
+  uint8_t  batt_soc = 85;
+  int8_t   batt_temp_c = 25;
+  uint8_t  batt_cycles = 0;
+  uint8_t  batt_status = 0;
+
+  // IMU (semantic)
+  float acc_gx = 0.0f, acc_gy = 0.0f, acc_gz = 1.0f;
+  float gyro_dpsx = 0.0f, gyro_dpsy = 0.0f, gyro_dpsz = 0.0f;
+  float mag_mgx = 0.0f, mag_mgy = 0.0f, mag_mgz = 0.0f;
+  uint8_t imu_status = 0;
+
+  // Motor status
+  int8_t   motor_throttle = 0;
+  int8_t   motor_steering = 0;
+  uint16_t motor_current_ma = 0;
+  int8_t   motor_driver_temp = 30;
+  uint8_t  motor_pwm = 0;
+};
+
+static int16_t clamp_i16(long v) {
+  if (v > 32767) return 32767;
+  if (v < -32768) return -32768;
+  return static_cast<int16_t>(v);
+}
+static uint8_t clamp_u8(long v) {
+  if (v < 0) return 0;
+  if (v > 255) return 255;
+  return static_cast<uint8_t>(v);
+}
+
+// -----------------------------
+// Scenario model
+// -----------------------------
+struct Event {
+  uint32_t t_ms = 0;
+  std::vector<std::pair<std::string,std::string>> kv;
+};
+
+struct Scenario {
+  std::string name;   // filename
+  std::string path;   // full path
+  std::vector<std::pair<std::string,std::string>> init_kv;
+  std::vector<Event> events;
+  uint32_t duration_ms = 0;
+};
+
+static std::string trim(const std::string& s)
+{
+  size_t b = 0;
+  while (b < s.size() && std::isspace((unsigned char)s[b])) b++;
+  size_t e = s.size();
+  while (e > b && std::isspace((unsigned char)s[e-1])) e--;
+  return s.substr(b, e-b);
+}
+
+static bool split_kv(const std::string& token, std::string& k, std::string& v)
+{
+  const size_t eq = token.find('=');
+  if (eq == std::string::npos) return false;
+  k = trim(token.substr(0, eq));
+  v = trim(token.substr(eq+1));
+  return !k.empty();
+}
+
+static void apply_kv(SimState& st, const std::string& k, const std::string& v)
+{
+  auto to_l = [&](const std::string& s)->long { return std::strtol(s.c_str(), nullptr, 10); };
+  auto to_ul = [&](const std::string& s)->unsigned long { return std::strtoul(s.c_str(), nullptr, 10); };
+  auto to_f = [&](const std::string& s)->float { return std::strtof(s.c_str(), nullptr); };
+
+  // Heartbeat
+  if (k == "hb_state") st.hb_state = clamp_u8((long)to_ul(v));
+  else if (k == "hb_errors") st.hb_errors = clamp_u8((long)to_ul(v));
+  else if (k == "hb_mode") st.hb_mode = clamp_u8((long)to_ul(v));
+
+  // Emergency stop
+  else if (k == "estop_active") st.estop_active = (clamp_u8((long)to_ul(v)) ? 1 : 0);
+  else if (k == "estop_source") st.estop_source = clamp_u8((long)to_ul(v));
+  else if (k == "estop_mm") st.estop_mm = static_cast<uint16_t>(to_ul(v));
+  else if (k == "estop_reason") st.estop_reason = clamp_u8((long)to_ul(v));
+
+  // Wheel speed
+  else if (k == "rpm") st.rpm = clamp_i16(to_l(v));
+  else if (k == "pulses") st.pulses = static_cast<uint32_t>(to_ul(v));
+  else if (k == "direction") st.direction = clamp_u8((long)to_ul(v));
+  else if (k == "wheel_status") st.wheel_status = clamp_u8((long)to_ul(v));
+
+  // ToF
+  else if (k == "tof_mm") st.tof_mm = static_cast<uint16_t>(to_ul(v));
+  else if (k == "tof_zone") st.tof_zone = clamp_u8((long)to_ul(v));
+  else if (k == "tof_ts") st.tof_target_status = clamp_u8((long)to_ul(v));
+  else if (k == "tof_count") st.tof_count = clamp_u8((long)to_ul(v));
+  else if (k == "tof_status") st.tof_status = clamp_u8((long)to_ul(v));
+
+  // Environment
+  else if (k == "env_temp_c") st.env_temp_c = to_f(v);
+  else if (k == "env_humidity") st.env_humidity = to_f(v);
+  else if (k == "env_light_lux") st.env_light_lux = static_cast<uint32_t>(to_ul(v));
+  else if (k == "env_pressure_hpa") st.env_pressure_hpa = to_f(v);
+  else if (k == "env_status") st.env_status = clamp_u8((long)to_ul(v));
+
+  // Battery
+  else if (k == "batt_mv") st.batt_mv = static_cast<uint16_t>(to_ul(v));
+  else if (k == "batt_ma") st.batt_ma = clamp_i16(to_l(v));
+  else if (k == "batt_soc") st.batt_soc = clamp_u8((long)to_ul(v));
+  else if (k == "batt_temp_c") st.batt_temp_c = static_cast<int8_t>(to_l(v));
+  else if (k == "batt_cycles") st.batt_cycles = clamp_u8((long)to_ul(v));
+  else if (k == "batt_status") st.batt_status = clamp_u8((long)to_ul(v));
+
+  // IMU
+  else if (k == "acc_gx") st.acc_gx = to_f(v);
+  else if (k == "acc_gy") st.acc_gy = to_f(v);
+  else if (k == "acc_gz") st.acc_gz = to_f(v);
+  else if (k == "gyro_dpsx") st.gyro_dpsx = to_f(v);
+  else if (k == "gyro_dpsy") st.gyro_dpsy = to_f(v);
+  else if (k == "gyro_dpsz") st.gyro_dpsz = to_f(v);
+  else if (k == "mag_mgx") st.mag_mgx = to_f(v);
+  else if (k == "mag_mgy") st.mag_mgy = to_f(v);
+  else if (k == "mag_mgz") st.mag_mgz = to_f(v);
+  else if (k == "imu_status") st.imu_status = clamp_u8((long)to_ul(v));
+
+  // Motor status
+  else if (k == "motor_throttle") st.motor_throttle = static_cast<int8_t>(to_l(v));
+  else if (k == "motor_steering") st.motor_steering = static_cast<int8_t>(to_l(v));
+  else if (k == "motor_current_ma") st.motor_current_ma = static_cast<uint16_t>(to_ul(v));
+  else if (k == "motor_driver_temp") st.motor_driver_temp = static_cast<int8_t>(to_l(v));
+  else if (k == "motor_pwm") st.motor_pwm = clamp_u8((long)to_ul(v));
+
+  else {
+    std::cerr << "[EMU] Unknown key: " << k << "\n";
+  }
+}
+
+static Scenario load_scenario_file(const fs::path& p)
+{
+  Scenario sc;
+  sc.name = p.filename().string();
+  sc.path = p.string();
+
+  std::ifstream in(sc.path.c_str());
+  if (!in) throw std::runtime_error("Failed to open scenario: " + sc.path);
+
+  std::string line;
+  uint32_t ln = 0;
+
+  while (std::getline(in, line)) {
+    ln++;
+    line = trim(line);
+    if (line.empty() || line[0] == '#') continue;
+
+    // @init ...
+    if (line.rfind("@init", 0) == 0) {
+      std::istringstream iss(line.substr(5));
+      std::string tok;
+      while (iss >> tok) {
+        std::string k,v;
+        if (split_kv(tok, k, v)) sc.init_kv.push_back({k,v});
+      }
+      continue;
+    }
+
+    std::istringstream iss(line);
+    std::string tok;
+    Event ev;
+    bool has_t = false;
+
+    while (iss >> tok) {
+      std::string k, v;
+      if (!split_kv(tok, k, v)) continue;
+
+      if (k == "t" || k == "t_ms") {
+        ev.t_ms = static_cast<uint32_t>(std::strtoul(v.c_str(), nullptr, 10));
+        has_t = true;
+      } else {
+        ev.kv.push_back({k, v});
+      }
+    }
+
+    if (!has_t) {
+      std::cerr << "[EMU] " << sc.name << ": line " << ln << ": missing t=..., skipping\n";
+      continue;
+    }
+    sc.events.push_back(ev);
+  }
+
+  std::sort(sc.events.begin(), sc.events.end(),
+            [](const Event& a, const Event& b){ return a.t_ms < b.t_ms; });
+
+  if (!sc.events.empty()) sc.duration_ms = sc.events.back().t_ms;
+  return sc;
+}
+
+static std::vector<Scenario> load_scenarios_dir(const std::string& dir)
+{
+  std::vector<Scenario> out;
+  fs::path root(dir);
+  if (!fs::exists(root)) throw std::runtime_error("Scenario dir does not exist: " + dir);
+  if (!fs::is_directory(root)) throw std::runtime_error("Not a directory: " + dir);
+
+  for (auto const& ent : fs::directory_iterator(root)) {
+    if (!ent.is_regular_file()) continue;
+    const fs::path p = ent.path();
+    const std::string ext = p.extension().string();
+    if (ext != ".txt" && ext != ".scn" && ext != ".scenario") continue;
+
+    try {
+      Scenario sc = load_scenario_file(p);
+      if (sc.events.empty() && sc.init_kv.empty()) {
+        std::cerr << "[EMU] Skipping empty scenario: " << sc.name << "\n";
+        continue;
+      }
+      out.push_back(sc);
+    } catch (const std::exception& e) {
+      std::cerr << "[EMU] Failed to load " << p.filename().string() << ": " << e.what() << "\n";
+    }
+  }
+
+  std::sort(out.begin(), out.end(), [](const Scenario& a, const Scenario& b){
+    return a.name < b.name;
+  });
+
+  return out;
+}
+
+// -----------------------------
+// Build frames from SimState using can_id.h structs
+// -----------------------------
+static WheelSpeed_t make_wheel(const SimState& st)
+{
+  WheelSpeed_t w{};
+  w.rpm          = st.rpm;
+  w.total_pulses = st.pulses;
+  w.direction    = st.direction;
+  w.status       = st.wheel_status;
+  return w;
+}
+
+static Heartbeat_t make_hb(const SimState& st, uint32_t uptime_ms)
+{
+  Heartbeat_t h{};
+  h.state     = st.hb_state;
+  h.uptime_ms = uptime_ms;
+  h.errors    = st.hb_errors;
+  h.mode      = st.hb_mode;
+  h.crc       = 0;
+  h.crc       = crc8(reinterpret_cast<const uint8_t*>(&h), sizeof(h) - 1);
+  return h;
+}
+
+static Environment_t make_env(const SimState& st)
+{
+  Environment_t e{};
+  const long temp_x100 = std::lround(st.env_temp_c * 100.0f);
+  e.temperature = clamp_i16(temp_x100);
+
+  float hum = st.env_humidity;
+  if (hum < 0.0f) hum = 0.0f;
+  if (hum > 100.0f) hum = 100.0f;
+  e.humidity = static_cast<uint8_t>(std::lround(hum));
+
+  uint32_t amb = st.env_light_lux / 100U;
+  if (amb > 255U) amb = 255U;
+  e.ambient_light_x100 = static_cast<uint8_t>(amb);
+
+  const uint32_t pressure_pa = static_cast<uint32_t>(std::lround(st.env_pressure_hpa * 100.0f)); // hPa -> Pa
+  e.pressure = (pressure_pa & 0xFFFFFFu);
+
+  e.status = st.env_status;
+  return e;
+}
+
+static BatteryStatus_t make_batt(const SimState& st)
+{
+  BatteryStatus_t b{};
+  b.voltage_mv  = st.batt_mv;
+  b.current_ma  = st.batt_ma;
+  b.soc         = st.batt_soc;
+  b.temperature = st.batt_temp_c;
+  b.cycles      = st.batt_cycles;
+  b.status      = st.batt_status;
+  return b;
+}
+
+static ImuAccel_t make_accel(const SimState& st)
+{
+  ImuAccel_t a{};
+  a.acc_x = clamp_i16(std::lround(st.acc_gx * 1000.0f));
+  a.acc_y = clamp_i16(std::lround(st.acc_gy * 1000.0f));
+  a.acc_z = clamp_i16(std::lround(st.acc_gz * 1000.0f));
+  a.reserved = 0;
+  a.status   = st.imu_status;
+  return a;
+}
+
+static ImuGyro_t make_gyro(const SimState& st)
+{
+  ImuGyro_t g{};
+  g.gyro_x = clamp_i16(std::lround(st.gyro_dpsx * 10.0f));
+  g.gyro_y = clamp_i16(std::lround(st.gyro_dpsy * 10.0f));
+  g.gyro_z = clamp_i16(std::lround(st.gyro_dpsz * 10.0f));
+  g.reserved = 0;
+  g.status   = st.imu_status;
+  return g;
+}
+
+static ImuMag_t make_mag(const SimState& st)
+{
+  ImuMag_t m{};
+  m.mag_x = clamp_i16(std::lround(st.mag_mgx));
+  m.mag_y = clamp_i16(std::lround(st.mag_mgy));
+  m.mag_z = clamp_i16(std::lround(st.mag_mgz));
+  m.reserved = 0;
+  m.status   = st.imu_status;
+  return m;
+}
+
+static ToFDistance_t make_tof(const SimState& st)
+{
+  ToFDistance_t t{};
+  t.min_distance_mm = st.tof_mm;
+  t.nearest_zone    = st.tof_zone;
+  t.target_status   = st.tof_target_status;
+  t.detection_count = st.tof_count;
+  t.reserved[0] = 0;
+  t.reserved[1] = 0;
+  t.status = st.tof_status;
+  return t;
+}
+
+static EmergencyStop_t make_estop(const SimState& st)
+{
+  EmergencyStop_t e{};
+  e.active      = st.estop_active;
+  e.source      = st.estop_source;
+  e.distance_mm = st.estop_mm;
+  e.reason      = st.estop_reason;
+  e.reserved[0] = 0;
+  e.reserved[1] = 0;
+  e.crc         = 0;
+  e.crc         = crc8(reinterpret_cast<const uint8_t*>(&e), sizeof(e) - 1);
+  return e;
+}
+
+static MotorStatus_t make_motor_status(const SimState& st, uint8_t counter)
+{
+  MotorStatus_t m{};
+  m.actual_throttle  = st.motor_throttle;
+  m.actual_steering  = st.motor_steering;
+  m.motor_current_ma = st.motor_current_ma;
+  m.driver_temp      = st.motor_driver_temp;
+  m.pwm_duty         = st.motor_pwm;
+  m.counter          = counter;
+  m.crc              = 0;
+  m.crc              = crc8(reinterpret_cast<const uint8_t*>(&m), sizeof(m) - 1);
+  return m;
+}
+
+// -----------------------------
+// Time helpers
+// -----------------------------
+static uint64_t now_ms()
+{
+  using namespace std::chrono;
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+// -----------------------------
+// Global shared state
+// -----------------------------
+static std::mutex g_state_mtx;
+static SimState g_state;
+static const SimState g_defaults; // value-initialized defaults
+
+struct Playback {
+  bool playing = false;
+  bool loop = false;
+  size_t scenario_index = 0;      // index into g_scenarios
+  size_t next_event_idx = 0;
+  uint64_t start_ms = 0;          // wall-clock start
+};
+
+static std::mutex g_play_mtx;
+static Playback g_play;
+static std::vector<Scenario> g_scenarios;
+static std::string g_scenario_dir;
+
+static std::atomic<bool> g_running(true);
+
+// Apply init + any t=0 events to current state (caller holds g_state_mtx)
+static void apply_scenario_start_locked(const Scenario& sc)
+{
+  g_state = g_defaults;
+  for (const auto& kv : sc.init_kv) apply_kv(g_state, kv.first, kv.second);
+  // Apply t=0 events
+  for (const auto& ev : sc.events) {
+    if (ev.t_ms != 0) break;
+    for (const auto& kv : ev.kv) apply_kv(g_state, kv.first, kv.second);
+  }
+}
+
+// -----------------------------
+// Scenario player thread
+// -----------------------------
+static void scenario_player_loop()
+{
+  while (g_running.load()) {
+    Scenario sc;
+    Playback pb;
+
+    {
+      std::lock_guard<std::mutex> lk(g_play_mtx);
+      pb = g_play;
+      if (!pb.playing || g_scenarios.empty() || pb.scenario_index >= g_scenarios.size()) {
+        // idle
+        // (keep last state; do not reset)
+        // Sleep small and retry
+        //
+        // Note: we copy pb above so we can avoid holding mutex while sleeping
+      }
+    }
+
+    if (!pb.playing || g_scenarios.empty() || pb.scenario_index >= g_scenarios.size()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      continue;
+    }
+
+    sc = g_scenarios[pb.scenario_index];
+
+    const uint64_t now = now_ms();
+    const uint32_t elapsed = static_cast<uint32_t>(now - pb.start_ms);
+
+    // Apply due events
+    bool reached_end = false;
+    {
+      std::lock_guard<std::mutex> lk_state(g_state_mtx);
+
+      size_t i = pb.next_event_idx;
+      while (i < sc.events.size() && sc.events[i].t_ms <= elapsed) {
+        for (const auto& kv : sc.events[i].kv) apply_kv(g_state, kv.first, kv.second);
+        i++;
+      }
+
+      // write back next_event_idx
+      {
+        std::lock_guard<std::mutex> lk_play(g_play_mtx);
+        // scenario might have changed; only write if still same one and playing
+        if (g_play.playing && g_play.scenario_index == pb.scenario_index) {
+          g_play.next_event_idx = i;
+        }
+      }
+
+      reached_end = (i >= sc.events.size());
+    }
+
+    if (reached_end) {
+      const uint32_t GRACE_MS = 1000;
+      if (elapsed >= sc.duration_ms + GRACE_MS) {
+        std::lock_guard<std::mutex> lk(g_play_mtx);
+        if (g_play.playing && g_play.scenario_index == pb.scenario_index) {
+          if (g_play.loop) {
+            g_play.start_ms = now_ms();
+            g_play.next_event_idx = 0;
+            // reset state to defaults + init
+            std::lock_guard<std::mutex> lk_state(g_state_mtx);
+            apply_scenario_start_locked(sc);
+          } else {
+            g_play.playing = false;
+          }
+        }
+      }
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+}
+
+// -----------------------------
+// CAN sender thread
+// -----------------------------
+struct Periods {
+  uint32_t motor = CAN_PERIOD_MOTOR_STATUS_MS;
+  uint32_t imu_fast = CAN_PERIOD_IMU_FAST_MS;
+  uint32_t imu_mag  = CAN_PERIOD_IMU_MAG_MS;
+  uint32_t wheel = CAN_PERIOD_WHEEL_SPEED_MS;
+  uint32_t tof = CAN_PERIOD_TOF_MS;
+  uint32_t env = CAN_PERIOD_ENVIRONMENT_MS;
+  uint32_t batt = CAN_PERIOD_BATTERY_MS;
+  uint32_t hb = CAN_PERIOD_HEARTBEAT_MS;
+  uint32_t estop = CAN_PERIOD_HEARTBEAT_MS; // default: same as heartbeat
+};
+
+static void can_sender_loop(int sock, Periods P)
+{
+  uint64_t t0 = now_ms();
+
+  uint64_t next_motor = t0;
+  uint64_t next_imu   = t0;
+  uint64_t next_mag   = t0;
+  uint64_t next_wheel = t0;
+  uint64_t next_tof   = t0;
+  uint64_t next_env   = t0;
+  uint64_t next_batt  = t0;
+  uint64_t next_hb    = t0;
+  uint64_t next_estop = t0;
+
+  uint8_t motor_counter = 0;
+
+  while (g_running.load()) {
+
+    if (!g_tx_enabled.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      continue;
+    }
+    const uint64_t now = now_ms();
+    const uint32_t uptime = static_cast<uint32_t>(now - t0);
+
+    SimState st;
+    {
+      std::lock_guard<std::mutex> lk(g_state_mtx);
+      st = g_state;
+    }
+
+    if (now >= next_motor) {
+      MotorStatus_t m = make_motor_status(st, motor_counter++);
+      send_payload8(sock, CAN_ID_MOTOR_STATUS, &m);
+      next_motor += P.motor;
+    }
+
+    if (now >= next_imu) {
+      ImuAccel_t a = make_accel(st);
+      ImuGyro_t  g = make_gyro(st);
+      send_payload8(sock, CAN_ID_IMU_ACCEL, &a);
+      send_payload8(sock, CAN_ID_IMU_GYRO,  &g);
+      next_imu += P.imu_fast;
+    }
+
+    if (now >= next_mag) {
+      ImuMag_t m = make_mag(st);
+      send_payload8(sock, CAN_ID_IMU_MAG, &m);
+      next_mag += P.imu_mag;
+    }
+
+    if (now >= next_wheel) {
+      WheelSpeed_t w = make_wheel(st);
+      send_payload8(sock, CAN_ID_WHEEL_SPEED, &w);
+      next_wheel += P.wheel;
+    }
+
+    if (now >= next_tof) {
+      ToFDistance_t t = make_tof(st);
+      send_payload8(sock, CAN_ID_TOF_DISTANCE, &t);
+      next_tof += P.tof;
+    }
+
+    if (now >= next_env) {
+      Environment_t e = make_env(st);
+      send_payload8(sock, CAN_ID_ENVIRONMENT, &e);
+      next_env += P.env;
+    }
+
+    if (now >= next_batt) {
+      BatteryStatus_t b = make_batt(st);
+      send_payload8(sock, CAN_ID_BATTERY, &b);
+      next_batt += P.batt;
+    }
+
+    if (now >= next_hb) {
+      Heartbeat_t h = make_hb(st, uptime);
+      send_payload8(sock, CAN_ID_HEARTBEAT_STM32, &h);
+      next_hb += P.hb;
+    }
+
+    if (now >= next_estop) {
+      EmergencyStop_t e = make_estop(st);
+      send_payload8(sock, CAN_ID_EMERGENCY_STOP, &e);
+      next_estop += P.estop;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+}
+
+// -----------------------------
+// CLI
+// -----------------------------
+static void print_help()
+{
+  std::cout <<
+    "Commands:\n"
+    "  help\n"
+    "  list\n"
+    "  play <index|name>\n"
+    "  stop\n"
+    "  loop on|off\n"
+    "  status\n"
+    "  show\n"
+    "  reset\n"
+    "  reload\n"
+    "  tx on|off\n"
+    "  quit\n";
+}
+
+static void cmd_list()
+{
+  if (g_scenarios.empty()) {
+    std::cout << "(no scenarios loaded)\n";
+    return;
+  }
+  for (size_t i = 0; i < g_scenarios.size(); ++i) {
+    std::cout << i << ") " << g_scenarios[i].name
+              << "  (events=" << g_scenarios[i].events.size()
+              << ", duration=" << g_scenarios[i].duration_ms << "ms)\n";
+  }
+}
+
+static bool parse_index_or_name(const std::string& s, size_t& out_idx)
+{
+  // try integer
+  char* end = nullptr;
+  long v = std::strtol(s.c_str(), &end, 10);
+  if (end && *end == '\0') {
+    if (v < 0) return false;
+    out_idx = static_cast<size_t>(v);
+    return true;
+  }
+
+  // try name match
+  for (size_t i = 0; i < g_scenarios.size(); ++i) {
+    if (g_scenarios[i].name == s) { out_idx = i; return true; }
+  }
+  return false;
+}
+
+static void cmd_play(const std::string& arg)
+{
+  if (g_scenarios.empty()) {
+    std::cout << "No scenarios loaded. Use 'reload' or check the folder.\n";
+    return;
+  }
+
+  size_t idx = 0;
+  if (!parse_index_or_name(arg, idx) || idx >= g_scenarios.size()) {
+    std::cout << "Unknown scenario: " << arg << "\n";
+    return;
+  }
+
+  const Scenario& sc = g_scenarios[idx];
+
+  {
+    std::lock_guard<std::mutex> lk_state(g_state_mtx);
+    apply_scenario_start_locked(sc);
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(g_play_mtx);
+    g_play.playing = true;
+    g_play.scenario_index = idx;
+    g_play.next_event_idx = 0;
+    g_play.start_ms = now_ms();
+  }
+
+  std::cout << "[OK] Playing " << sc.name << " (loop=" << (g_play.loop ? "on" : "off") << ")\n";
+}
+
+static void cmd_stop()
+{
+  std::lock_guard<std::mutex> lk(g_play_mtx);
+  g_play.playing = false;
+  std::cout << "[OK] Stopped\n";
+}
+
+static void cmd_loop(const std::string& arg)
+{
+  bool on = (arg == "on" || arg == "1" || arg == "true");
+  {
+    std::lock_guard<std::mutex> lk(g_play_mtx);
+    g_play.loop = on;
+  }
+  std::cout << "[OK] loop=" << (on ? "on" : "off") << "\n";
+}
+
+static void cmd_status()
+{
+  Playback pb;
+  {
+    std::lock_guard<std::mutex> lk(g_play_mtx);
+    pb = g_play;
+  }
+
+  std::cout << "playing=" << (pb.playing ? "yes" : "no")
+            << " loop=" << (pb.loop ? "on" : "off");
+
+  if (pb.playing && !g_scenarios.empty() && pb.scenario_index < g_scenarios.size()) {
+    std::cout << " scenario=" << g_scenarios[pb.scenario_index].name
+              << " next_event_idx=" << pb.next_event_idx;
+  }
+  std::cout << "\n";
+}
+
+static void cmd_show()
+{
+  SimState st;
+  {
+    std::lock_guard<std::mutex> lk(g_state_mtx);
+    st = g_state;
+  }
+
+  std::cout
+    << "hb_state=" << (int)st.hb_state
+    << " hb_errors=" << (int)st.hb_errors
+    << " hb_mode=" << (int)st.hb_mode
+    << " | estop_active=" << (int)st.estop_active
+    << " source=" << (int)st.estop_source
+    << " dist_mm=" << st.estop_mm
+    << " reason=" << (int)st.estop_reason
+    << " | rpm=" << st.rpm
+    << " pulses=" << st.pulses
+    << " dir=" << (int)st.direction
+    << " | tof_mm=" << st.tof_mm
+    << " zone=" << (int)st.tof_zone
+    << " targets=" << (int)st.tof_count
+    << " | env=" << st.env_temp_c << "C " << st.env_humidity << "% " << st.env_light_lux << "lux " << st.env_pressure_hpa << "hPa"
+    << " | batt_mv=" << st.batt_mv << " soc=" << (int)st.batt_soc
+    << " | motor thr=" << (int)st.motor_throttle << " steer=" << (int)st.motor_steering
+    << "\n";
+}
+
+static void cmd_reset()
+{
+  {
+    std::lock_guard<std::mutex> lk_state(g_state_mtx);
+    g_state = g_defaults;
+  }
+  std::cout << "[OK] State reset to defaults\n";
+}
+
+static void cmd_reload()
+{
+  try {
+    g_scenarios = load_scenarios_dir(g_scenario_dir);
+    std::cout << "[OK] Reloaded scenarios (" << g_scenarios.size() << ") from " << g_scenario_dir << "\n";
+  } catch (const std::exception& e) {
+    std::cout << "[ERR] " << e.what() << "\n";
+  }
+}
+
+static void cli_loop()
+{
+  print_help();
+  std::string line;
+
+  while (g_running.load()) {
+    std::cout << "emu> " << std::flush;
+    if (!std::getline(std::cin, line)) {
+      g_running.store(false);
+      break;
+    }
+
+    line = trim(line);
+    if (line.empty()) continue;
+
+    std::istringstream iss(line);
+    std::string cmd;
+    iss >> cmd;
+
+    if (cmd == "help") print_help();
+    else if (cmd == "list") cmd_list();
+    else if (cmd == "play") {
+      std::string arg; iss >> arg;
+      if (arg.empty()) {
+        std::cout << "usage: play <index|name>\n";
+        g_tx_enabled.store(true);
+      }
+      else cmd_play(arg);
+    }
+    else if (cmd == "stop") cmd_stop();
+    else if (cmd == "loop") {
+      std::string arg; iss >> arg;
+      if (arg.empty()) std::cout << "usage: loop on|off\n";
+      else cmd_loop(arg);
+    }
+    else if (cmd == "status") cmd_status();
+    else if (cmd == "show") cmd_show();
+    else if (cmd == "reset") cmd_reset();
+    else if (cmd == "reload") cmd_reload();
+    else if (cmd == "tx") {
+      std::string arg; iss >> arg;
+      if (arg == "on") {g_tx_enabled.store(true); std::cout << "[OK] tx=on\n";}
+      else if (arg == "off") { g_tx_enabled.store(false); std::cout << "[OK] tx=off\n"; }
+      else std::cout << "usage: tx on|off\n";
+    }
+    else if (cmd == "quit" || cmd == "exit") {
+      g_running.store(false);
+      break;
+    }
+    else {
+      std::cout << "Unknown command. Type 'help'.\n";
+    }
+  }
+}
+
+static void usage(const char* prog)
+{
+  std::cerr
+    << "Usage:\n"
+    << "  " << prog << " <iface> <scenario_dir> [--p-wheel=MS] [--p-tof=MS] [--p-imu=MS] [--p-mag=MS] [--p-env=MS] [--p-batt=MS] [--p-hb=MS] [--p-motor=MS] [--p-estop=MS]\n";
+}
+
+int main(int argc, char** argv)
+{
+  if (argc < 3) { usage(argv[0]); return 1; }
+
+  const std::string iface = argv[1];
+  g_scenario_dir = argv[2];
+
+  Periods P;
+  auto parse_u32 = [](const std::string& s)->uint32_t {
+    return static_cast<uint32_t>(std::strtoul(s.c_str(), nullptr, 10));
+  };
+
+  for (int i = 3; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a.rfind("--p-motor=",0)==0) P.motor = parse_u32(a.substr(10));
+    else if (a.rfind("--p-imu=",0)==0)   P.imu_fast = parse_u32(a.substr(8));
+    else if (a.rfind("--p-mag=",0)==0)   P.imu_mag  = parse_u32(a.substr(8));
+    else if (a.rfind("--p-wheel=",0)==0) P.wheel = parse_u32(a.substr(10));
+    else if (a.rfind("--p-tof=",0)==0)   P.tof   = parse_u32(a.substr(8));
+    else if (a.rfind("--p-env=",0)==0)   P.env   = parse_u32(a.substr(8));
+    else if (a.rfind("--p-batt=",0)==0)  P.batt  = parse_u32(a.substr(9));
+    else if (a.rfind("--p-hb=",0)==0)    P.hb    = parse_u32(a.substr(7));
+    else if (a.rfind("--p-estop=",0)==0) P.estop = parse_u32(a.substr(10));
+    else {
+      std::cerr << "[EMU] Unknown arg: " << a << "\n";
+    }
+  }
+
+  try {
+    g_scenarios = load_scenarios_dir(g_scenario_dir);
+  } catch (const std::exception& e) {
+    std::cerr << "[EMU] " << e.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "[EMU] Loaded " << g_scenarios.size() << " scenario(s) from " << g_scenario_dir << "\n";
+  std::cout << "[EMU] IDs (from can_id.h): wheel=0x" << std::hex << CAN_ID_WHEEL_SPEED
+            << " imu_acc=0x" << CAN_ID_IMU_ACCEL
+            << " imu_gyro=0x" << CAN_ID_IMU_GYRO
+            << " imu_mag=0x" << CAN_ID_IMU_MAG
+            << " env=0x" << CAN_ID_ENVIRONMENT
+            << " batt=0x" << CAN_ID_BATTERY
+            << " tof=0x" << CAN_ID_TOF_DISTANCE
+            << " hb=0x" << CAN_ID_HEARTBEAT_STM32
+            << " estop=0x" << CAN_ID_EMERGENCY_STOP
+            << " motor_status=0x" << CAN_ID_MOTOR_STATUS
+            << std::dec << "\n";
+
+  const int sock = open_can_tx_socket(iface);
+  if (sock < 0) return 1;
+
+  // threads
+  std::thread t_player(scenario_player_loop);
+  std::thread t_sender(can_sender_loop, sock, P);
+
+  // main thread = CLI
+  cli_loop();
+
+  // shutdown
+  g_running.store(false);
+  if (t_player.joinable()) t_player.join();
+  if (t_sender.joinable()) t_sender.join();
+
+  ::close(sock);
+  std::cout << "[EMU] Bye.\n";
+  return 0;
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/app_context.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/app_context.hpp
@@ -1,0 +1,78 @@
+#pragma once
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "sim_state.hpp"
+#include "../../../inc/can_id.h"
+
+struct Periods {
+  uint32_t motor;
+  uint32_t imu_fast;
+  uint32_t imu_mag;
+  uint32_t wheel;
+  uint32_t tof;
+  uint32_t env;
+  uint32_t batt;
+  uint32_t hb;
+  uint32_t estop;
+};
+
+// -----------------------------
+// Scenario model
+// -----------------------------
+struct Event {
+  uint32_t t_ms = 0;
+  std::vector<std::pair<std::string,std::string>> kv;
+};
+
+struct Scenario {
+  std::string name;   // filename
+  std::string path;   // full path
+  std::vector<std::pair<std::string,std::string>> init_kv;
+  std::vector<Event> events;
+  uint32_t duration_ms = 0;
+};
+
+// -----------------------------
+// Playback Control State
+// -----------------------------
+struct Playback {
+  bool playing = false;
+  bool loop = false;
+
+  size_t scenario_index = 0;
+  size_t next_event_idx = 0;
+
+  uint64_t start_ms = 0;
+};
+
+struct AppContext {
+  // lifecycle
+  std::atomic<bool> running{true};
+
+  // config
+  std::string scenario_dir;
+  Periods periods{
+    CAN_PERIOD_MOTOR_STATUS_MS,
+    CAN_PERIOD_IMU_FAST_MS,
+    CAN_PERIOD_IMU_MAG_MS,
+    CAN_PERIOD_WHEEL_SPEED_MS,
+    CAN_PERIOD_TOF_MS,
+    CAN_PERIOD_ENVIRONMENT_MS,
+    CAN_PERIOD_BATTERY_MS,
+    CAN_PERIOD_HEARTBEAT_MS,
+    CAN_PERIOD_HEARTBEAT_MS
+  };
+
+  // scenarios + playback control
+  std::mutex play_mtx;
+  Playback play{};
+  std::vector<Scenario> scenarios;
+
+  // shared simulated state
+  std::mutex state_mtx;
+  SimState state{};
+  SimState defaults{};
+};

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/can_sender.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/can_sender.hpp
@@ -1,0 +1,14 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <cstring>
+#include <mutex>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+int open_can_tx_socket(const std::string& ifname);
+bool send_payload8(int sock, uint32_t can_id, const void* payload8);

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/can_sender.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/can_sender.hpp
@@ -1,3 +1,4 @@
+#include <thread>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -10,5 +11,9 @@
 #include <linux/can.h>
 #include <linux/can/raw.h>
 
+#include "../../../inc/can_id.h"
+#include "../inc/frames_builder.hpp"
+
 int open_can_tx_socket(const std::string& ifname);
 bool send_payload8(int sock, uint32_t can_id, const void* payload8);
+void can_sender_loop(int sock, AppContext& ctx);

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/cli.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/cli.hpp
@@ -1,0 +1,21 @@
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+#include "../inc/sim_state.hpp"
+#include "../inc/app_context.hpp"
+#include "../inc/helpers.hpp"
+#include "../inc/scenario_loader.hpp"
+
+void print_help();
+void cmd_list(AppContext& ctx);
+void cmd_play(const std::string& arg, AppContext& ctx);
+void cmd_stop(AppContext& ctx);
+void cmd_loop(const std::string& arg, AppContext& ctx);
+void cmd_status(AppContext& ctx);
+void cmd_show(AppContext& ctx);
+void cmd_reset(AppContext& ctx);
+void cmd_reload(AppContext& ctx);
+void cli_loop(AppContext& ctx);

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/frames_builder.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/frames_builder.hpp
@@ -1,0 +1,16 @@
+#include <cmath>
+
+#include "../inc/helpers.hpp"
+#include "../inc/sim_state.hpp"
+#include "../inc/app_context.hpp"
+
+WheelSpeed_t make_wheel(const SimState& st);
+Heartbeat_t make_hb(const SimState& st, uint32_t uptime_ms);
+Environment_t make_env(const SimState& st);
+BatteryStatus_t make_batt(const SimState& st);
+ImuAccel_t make_accel(const SimState& st);
+ImuGyro_t make_gyro(const SimState& st);
+ImuMag_t make_mag(const SimState& st);
+ToFDistance_t make_tof(const SimState& st);
+EmergencyStop_t make_estop(const SimState& st);
+MotorStatus_t make_motor_status(const SimState& st, uint8_t counter);

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/helpers.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/helpers.hpp
@@ -1,0 +1,19 @@
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <chrono>
+#include <iostream>
+
+#include "../inc/sim_state.hpp"
+
+uint8_t crc8(const uint8_t* data, size_t len);
+int16_t clamp_i16(long v);
+uint8_t clamp_u8(long v);
+std::string trim(const std::string& s);
+bool split_kv(const std::string& token, std::string& k, std::string& v);
+void apply_kv(SimState& st, const std::string& k, const std::string& v);
+uint64_t now_ms();

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/scenario_loader.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/scenario_loader.hpp
@@ -1,0 +1,14 @@
+#include <vector>
+#include <fstream>
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#else
+  #error "C++17 <filesystem> required"
+#endif
+
+#include "app_context.hpp"
+#include "helpers.hpp"
+
+std::vector<Scenario> load_scenarios_dir(const std::string& dir);
+Scenario load_scenario_file(const fs::path& p);

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/scenario_loader.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/scenario_loader.hpp
@@ -12,3 +12,4 @@
 
 std::vector<Scenario> load_scenarios_dir(const std::string& dir);
 Scenario load_scenario_file(const fs::path& p);
+void apply_scenario_start_locked(AppContext& ctx, const Scenario& sc);

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/inc/sim_state.hpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/inc/sim_state.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+#include "../../../inc/can_id.h"
+
+struct SimState {
+  // Heartbeat
+  uint8_t hb_state  = SYSTEM_STATE_RUNNING;
+  uint8_t hb_errors = 0;
+  uint8_t hb_mode   = DRIVE_MODE_MANUAL;
+
+  // Emergency stop
+  uint8_t  estop_active = 0;
+  uint8_t  estop_source = 0;
+  uint16_t estop_mm     = 4000;
+  uint8_t  estop_reason = 0;
+
+  // Wheel speed
+  int16_t  rpm = 0;
+  uint32_t pulses = 0;
+  uint8_t  direction = 0;
+  uint8_t  wheel_status = 0;
+
+  // ToF
+  uint16_t tof_mm = 4000;
+  uint8_t  tof_zone = 255;
+  uint8_t  tof_target_status = 0;
+  uint8_t  tof_count = 0;
+  uint8_t  tof_status = 0;
+
+  // Environment
+  float    env_temp_c = 21.5f;
+  float    env_humidity = 50.0f;
+  uint32_t env_light_lux = 800;
+  float    env_pressure_hpa = 1013.25f;
+  uint8_t  env_status = 0;
+
+  // Battery
+  uint16_t batt_mv = 12300;
+  int16_t  batt_ma = 0;
+  uint8_t  batt_soc = 85;
+  int8_t   batt_temp_c = 25;
+  uint8_t  batt_cycles = 0;
+  uint8_t  batt_status = 0;
+
+  // IMU
+  float acc_gx = 0.0f, acc_gy = 0.0f, acc_gz = 1.0f;
+  float gyro_dpsx = 0.0f, gyro_dpsy = 0.0f, gyro_dpsz = 0.0f;
+  float mag_mgx = 0.0f, mag_mgy = 0.0f, mag_mgz = 0.0f;
+  uint8_t imu_status = 0;
+
+  // Motor
+  int8_t   motor_throttle = 0;
+  int8_t   motor_steering = 0;
+  uint16_t motor_current_ma = 0;
+  int8_t   motor_driver_temp = 30;
+  uint8_t  motor_pwm = 0;
+};

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/demo-drive.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/demo-drive.txt
@@ -1,0 +1,8 @@
+@init rpm=0 tof_mm=4000 batt_soc=90 env_temp_c=22.0
+
+t=500 rpm=200
+t=1500 rpm=400
+t=2500 tof_mm=900
+t=3000 tof_mm=350 estop_active=1 estop_source=0 estop_mm=350 estop_reason=1
+t=3500 rpm=0
+t=4500 estop_active=0

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/demo.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/demo.txt
@@ -1,0 +1,40 @@
+# Simple demo: drive, approach obstacle, trigger estop, change environment/battery.
+
+t=0 hb_state=3 hb_errors=0 hb_mode=1
+t=0 rpm=0 pulses=0 direction=0 wheel_status=0
+t=0 tof_mm=4000 tof_zone=255 tof_ts=0 tof_count=0 tof_status=0
+t=0 env_temp_c=21.5 env_humidity=52 env_light_lux=800 env_pressure_hpa=1013.2 env_status=0
+t=0 batt_mv=12300 batt_ma=-300 batt_soc=90 batt_temp_c=26 batt_cycles=0 batt_status=0
+
+# Move
+t=500  rpm=200 pulses=10
+t=1000 rpm=450 pulses=50
+t=1500 rpm=650 pulses=120
+
+# IMU small motion
+t=0 acc_gx=0.00 acc_gy=0.00 acc_gz=1.00 gyro_dpsx=0 gyro_dpsy=0 gyro_dpsz=0 imu_status=0
+t=2000 gyro_dpsz=12.3
+t=2600 acc_gx=0.08
+
+# Obstacle getting close (ToF)
+t=2000 tof_mm=1200 tof_zone=10 tof_ts=5 tof_count=1
+t=2500 tof_mm=600  tof_zone=10 tof_ts=5 tof_count=1
+t=2800 tof_mm=250  tof_zone=10 tof_ts=5 tof_count=1
+
+# Emergency stop triggers
+t=2850 estop_active=1 estop_source=0 estop_mm=250 estop_reason=1
+
+# Motor status 
+t=0 motor_throttle=0 motor_steering=0 motor_current_ma=0 motor_driver_temp=30 motor_pwm=0
+t=1500 motor_throttle=20 motor_current_ma=800 motor_pwm=90
+t=2850 motor_throttle=0 motor_current_ma=0 motor_pwm=0
+
+# Stop moving
+t=3200 rpm=0
+
+# Clear estop
+t=4500 estop_active=0 estop_reason=0 tof_mm=2000
+
+# Darken environment + drain battery
+t=5000 env_light_lux=40
+t=6000 batt_mv=11000 batt_soc=40 batt_status=4

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_battery.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_battery.txt
@@ -1,0 +1,11 @@
+# Battery: discharge then slight charge (regen / charger)
+@init batt_mv=12600 batt_ma=0 batt_soc=95 batt_temp_c=25 batt_cycles=12 batt_status=0
+
+t=0     batt_ma=300   batt_mv=12450 batt_soc=94
+t=1500  batt_ma=800   batt_mv=12250 batt_soc=92
+t=3000  batt_ma=1200  batt_mv=12050 batt_soc=89
+t=4500  batt_ma=1500  batt_mv=11880 batt_soc=86
+t=6000  batt_ma=900   batt_mv=12000 batt_soc=87
+t=7000  batt_ma=-200  batt_mv=12100 batt_soc=88
+t=8500  batt_ma=-500  batt_mv=12220 batt_soc=89
+t=10000 batt_ma=0     batt_mv=12300 batt_soc=90

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_environment.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_environment.txt
@@ -1,0 +1,11 @@
+# Environment: light + temp + humidity variation (day -> night -> day)
+@init env_temp_c=21.5 env_humidity=50 env_light_lux=800 env_pressure_hpa=1013.2 env_status=0
+
+t=0     env_light_lux=1200 env_temp_c=22.0 env_humidity=48
+t=1500  env_light_lux=2000 env_temp_c=23.5 env_humidity=45
+t=3000  env_light_lux=800  env_temp_c=22.5 env_humidity=50
+t=4500  env_light_lux=200  env_temp_c=20.0 env_humidity=60
+t=6000  env_light_lux=30   env_temp_c=18.5 env_humidity=70
+t=7500  env_light_lux=200  env_temp_c=19.5 env_humidity=65
+t=9000  env_light_lux=900  env_temp_c=21.0 env_humidity=55
+t=10500 env_light_lux=1500 env_temp_c=22.0 env_humidity=50

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_estop.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_estop.txt
@@ -1,0 +1,9 @@
+# Emergency stop: trigger close obstacle then release
+@init estop_active=0 estop_source=0 estop_mm=4000 estop_reason=0
+
+t=0     estop_active=0 estop_mm=4000
+t=1500  estop_active=0 estop_mm=1200
+t=2500  estop_active=1 estop_mm=450  estop_reason=1
+t=3500  estop_active=1 estop_mm=300  estop_reason=1
+t=5000  estop_active=0 estop_mm=1200 estop_reason=0
+t=6500  estop_active=0 estop_mm=4000 estop_reason=0

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_imu_accel.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_imu_accel.txt
@@ -1,0 +1,10 @@
+# IMU accel: simulate a quick braking event (longitudinal negative spike)
+@init acc_gx=0 acc_gy=0 acc_gz=1 imu_status=0 gyro_dpsx=0 gyro_dpsy=0 gyro_dpsz=0
+
+t=0    acc_gx=0.00
+t=800  acc_gx=0.10
+t=1200 acc_gx=-0.30
+t=1500 acc_gx=-0.80
+t=1800 acc_gx=-0.40
+t=2200 acc_gx=-0.10
+t=3000 acc_gx=0.00

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_imu_gyro.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_imu_gyro.txt
@@ -1,0 +1,21 @@
+# IMU Gyro: simulate turning left then right correction
+@init gyro_dpsx=0 gyro_dpsy=0 gyro_dpsz=0 imu_status=0
+
+# idle
+t=0    gyro_dpsz=0
+
+# start left turn (positive yaw)
+t=800  gyro_dpsz=15
+t=1200 gyro_dpsz=40
+t=1600 gyro_dpsz=75
+t=2000 gyro_dpsz=60
+t=2400 gyro_dpsz=30
+
+# sharp right correction (negative yaw)
+t=3000 gyro_dpsz=-40
+t=3400 gyro_dpsz=-70
+t=3800 gyro_dpsz=-30
+
+# stabilize
+t=4500 gyro_dpsz=0
+t=5500 gyro_dpsz=0

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_imu_mag.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_imu_mag.txt
@@ -1,0 +1,21 @@
+# IMU Magnetometer: simulate heading rotation
+@init mag_mgx=100 mag_mgy=0 mag_mgz=0 imu_status=0
+
+# facing north
+t=0    mag_mgx=100 mag_mgy=0
+
+# rotate toward east
+t=1000 mag_mgx=70  mag_mgy=70
+t=2000 mag_mgx=0   mag_mgy=100
+
+# rotate toward south
+t=3000 mag_mgx=-70 mag_mgy=70
+t=4000 mag_mgx=-100 mag_mgy=0
+
+# rotate toward west
+t=5000 mag_mgx=-70 mag_mgy=-70
+t=6000 mag_mgx=0   mag_mgy=-100
+
+# back to north
+t=7000 mag_mgx=70  mag_mgy=-70
+t=8000 mag_mgx=100 mag_mgy=0

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_motor.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_motor.txt
@@ -1,0 +1,10 @@
+# Motor status: throttle + steering sweep
+@init motor_throttle=0 motor_steering=0 motor_current_ma=0 motor_driver_temp=30 motor_pwm=0
+
+t=0     motor_throttle=0   motor_steering=0   motor_pwm=0
+t=1000  motor_throttle=10  motor_steering=0   motor_pwm=20
+t=2000  motor_throttle=30  motor_steering=10  motor_pwm=40
+t=3000  motor_throttle=60  motor_steering=-10 motor_pwm=70
+t=4000  motor_throttle=80  motor_steering=20  motor_pwm=90
+t=5200  motor_throttle=40  motor_steering=0   motor_pwm=50
+t=6500  motor_throttle=0   motor_steering=0   motor_pwm=0

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_tof_distance.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_tof_distance.txt
@@ -1,0 +1,13 @@
+# ToF: far -> approach -> near -> recover
+@init tof_mm=4000
+
+t=0    tof_mm=4000
+t=800  tof_mm=2500
+t=1400 tof_mm=1500
+t=2000 tof_mm=900
+t=2600 tof_mm=600
+t=3200 tof_mm=450
+t=3600 tof_mm=700
+t=4200 tof_mm=1200
+t=5200 tof_mm=2500
+t=6500 tof_mm=4000

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_wheel_speed.txt
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/scenarios/single_wheel_speed.txt
@@ -1,0 +1,18 @@
+# Wheel speed: min -> mid -> max -> jitter -> back to 0
+@init rpm=0 pulses=0 direction=0 wheel_status=0
+
+t=0    rpm=0
+t=500  rpm=50
+t=1000 rpm=150
+t=1500 rpm=300
+t=2000 rpm=600
+t=2500 rpm=900
+t=3000 rpm=1200
+t=3500 rpm=900
+t=3800 rpm=950
+t=4100 rpm=870
+t=4400 rpm=920
+t=4700 rpm=700
+t=5200 rpm=400
+t=6000 rpm=150
+t=7000 rpm=0

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/can_sender.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/can_sender.cpp
@@ -1,0 +1,49 @@
+#include "../inc/can_sender.hpp"
+
+// -----------------------------
+// SocketCAN helpers
+// -----------------------------
+int open_can_tx_socket(const std::string& ifname)
+{
+  int s = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+  if (s < 0) {
+    std::cerr << "[EMU] socket() failed: " << std::strerror(errno) << "\n";
+    return -1;
+  }
+
+  ifreq ifr{};
+  std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
+
+  if (::ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
+    std::cerr << "[EMU] ioctl(SIOCGIFINDEX) failed: " << std::strerror(errno) << "\n";
+    ::close(s);
+    return -1;
+  }
+
+  sockaddr_can addr{};
+  addr.can_family  = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (::bind(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    std::cerr << "[EMU] bind() failed: " << std::strerror(errno) << "\n";
+    ::close(s);
+    return -1;
+  }
+
+  std::cout << "[EMU] Sending on interface: " << ifname << "\n";
+  return s;
+}
+
+bool send_payload8(int sock, uint32_t can_id, const void* payload8)
+{
+  can_frame f{};
+  f.can_id  = can_id;
+  f.can_dlc = 8;
+  std::memcpy(f.data, payload8, 8);
+  const ssize_t n = ::write(sock, &f, sizeof(f));
+  if (n != static_cast<ssize_t>(sizeof(f))) {
+    std::cerr << "[EMU] write() failed/short: " << std::strerror(errno) << "\n";
+    return false;
+  }
+  return true;
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/can_sender.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/can_sender.cpp
@@ -47,3 +47,98 @@ bool send_payload8(int sock, uint32_t can_id, const void* payload8)
   }
   return true;
 }
+
+// -----------------------------
+// CAN sender thread
+// -----------------------------
+
+void can_sender_loop(int sock, AppContext& ctx)
+{
+  uint64_t t0 = now_ms();
+
+  uint64_t next_motor = t0;
+  uint64_t next_imu   = t0;
+  uint64_t next_mag   = t0;
+  uint64_t next_wheel = t0;
+  uint64_t next_tof   = t0;
+  uint64_t next_env   = t0;
+  uint64_t next_batt  = t0;
+  uint64_t next_hb    = t0;
+  uint64_t next_estop = t0;
+
+  uint8_t motor_counter = 0;
+
+  while (ctx.running.load()) {
+    const uint64_t now = now_ms();
+    const uint32_t uptime = static_cast<uint32_t>(now - t0);
+
+    // snapshot the latest state (under lock)
+    SimState st;
+    {
+      std::lock_guard<std::mutex> lk(ctx.play_mtx);
+      st = ctx.state;
+    }
+    // snapshot the periods (no lock needed since they are const)
+    const Periods& P = ctx.periods;
+
+    // Send frames - check each one
+    // if the time passed is equal or greater than the scheduled
+    if (now >= next_motor) {
+      MotorStatus_t m = make_motor_status(st, motor_counter++);
+      send_payload8(sock, CAN_ID_MOTOR_STATUS, &m);
+      next_motor += P.motor;
+    }
+
+    if (now >= next_imu) {
+      ImuAccel_t a = make_accel(st);
+      ImuGyro_t  g = make_gyro(st);
+      send_payload8(sock, CAN_ID_IMU_ACCEL, &a);
+      send_payload8(sock, CAN_ID_IMU_GYRO,  &g);
+      next_imu += P.imu_fast;
+    }
+
+    if (now >= next_mag) {
+      ImuMag_t m = make_mag(st);
+      send_payload8(sock, CAN_ID_IMU_MAG, &m);
+      next_mag += P.imu_mag;
+    }
+
+    if (now >= next_wheel) {
+      WheelSpeed_t w = make_wheel(st);
+      send_payload8(sock, CAN_ID_WHEEL_SPEED, &w);
+      next_wheel += P.wheel;
+    }
+
+    if (now >= next_tof) {
+      ToFDistance_t t = make_tof(st);
+      send_payload8(sock, CAN_ID_TOF_DISTANCE, &t);
+      next_tof += P.tof;
+    }
+
+    if (now >= next_env) {
+      Environment_t e = make_env(st);
+      send_payload8(sock, CAN_ID_ENVIRONMENT, &e);
+      next_env += P.env;
+    }
+
+    if (now >= next_batt) {
+      BatteryStatus_t b = make_batt(st);
+      send_payload8(sock, CAN_ID_BATTERY, &b);
+      next_batt += P.batt;
+    }
+
+    if (now >= next_hb) {
+      Heartbeat_t h = make_hb(st, uptime);
+      send_payload8(sock, CAN_ID_HEARTBEAT_STM32, &h);
+      next_hb += P.hb;
+    }
+
+    if (now >= next_estop) {
+      EmergencyStop_t e = make_estop(st);
+      send_payload8(sock, CAN_ID_EMERGENCY_STOP, &e);
+      next_estop += P.estop;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/cli.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/cli.cpp
@@ -1,0 +1,218 @@
+#include "../inc/cli.hpp"
+
+// -----------------------------
+// CLI
+// -----------------------------
+void print_help()
+{
+  std::cout <<
+    "Commands:\n"
+    "  help\n"
+    "  list\n"
+    "  play <index|name>\n"
+    "  stop\n"
+    "  loop on|off\n"
+    "  status\n"
+    "  show\n"
+    "  reset\n"
+    "  reload\n"
+    "  quit\n";
+}
+
+void cmd_list(AppContext& ctx)
+{
+  if (ctx.scenarios.empty()) {
+    std::cout << "(no scenarios loaded)\n";
+    return;
+  }
+  for (size_t i = 0; i < ctx.scenarios.size(); ++i) {
+    std::cout << i << ") " << ctx.scenarios[i].name
+              << "  (events=" << ctx.scenarios[i].events.size()
+              << ", duration=" << ctx.scenarios[i].duration_ms << "ms)\n";
+  }
+}
+
+bool parse_index_or_name(AppContext& ctx, const std::string& s, size_t& out_idx)
+{
+  // try integer
+  char* end = nullptr;
+  long v = std::strtol(s.c_str(), &end, 10);
+  if (end && *end == '\0') {
+    if (v < 0) return false;
+    out_idx = static_cast<size_t>(v);
+    return true;
+  }
+
+  // try name match
+  for (size_t i = 0; i < ctx.scenarios.size(); ++i) {
+    if (ctx.scenarios[i].name == s) { out_idx = i; return true; }
+  }
+  return false;
+}
+
+void cmd_play(const std::string& arg, AppContext& ctx)
+{
+  if (ctx.scenarios.empty()) {
+    std::cout << "No scenarios loaded. Use 'reload' or check the folder.\n";
+    return;
+  }
+
+  size_t idx = 0;
+  if (!parse_index_or_name(ctx, arg, idx) || idx >= ctx.scenarios.size()) {
+    std::cout << "Unknown scenario: " << arg << "\n";
+    return;
+  }
+
+  const Scenario& sc = ctx.scenarios[idx];
+
+  {
+    std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+    apply_scenario_start_locked(ctx, sc);
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(ctx.play_mtx);
+    ctx.play.playing = true;
+    ctx.play.scenario_index = idx;
+    ctx.play.next_event_idx = 0;
+    ctx.play.start_ms = now_ms();
+  }
+
+  std::cout << "[OK] Playing " << sc.name << " (loop=" << (ctx.play.loop ? "on" : "off") << ")\n";
+}
+
+void cmd_stop(AppContext& ctx)
+{
+  std::lock_guard<std::mutex> lk(ctx.play_mtx);
+  ctx.play.playing = false;
+  std::cout << "[OK] Stopped\n";
+}
+
+void cmd_loop(const std::string& arg, AppContext& ctx)
+{
+  bool on = (arg == "on" || arg == "1" || arg == "true");
+  {
+    std::lock_guard<std::mutex> lk(ctx.play_mtx);
+    ctx.play.loop = on;
+  }
+  std::cout << "[OK] loop=" << (on ? "on" : "off") << "\n";
+}
+
+void cmd_status(AppContext& ctx)
+{
+  Playback pb;
+  {
+    std::lock_guard<std::mutex> lk(ctx.play_mtx);
+    pb = ctx.play;
+  }
+
+  std::cout << "playing=" << (pb.playing ? "yes" : "no")
+            << " loop=" << (pb.loop ? "on" : "off");
+
+  if (pb.playing && !ctx.scenarios.empty() && pb.scenario_index < ctx.scenarios.size()) {
+    std::cout << " scenario=" << ctx.scenarios[pb.scenario_index].name
+              << " next_event_idx=" << pb.next_event_idx;
+  }
+  std::cout << "\n";
+}
+
+void cmd_show(AppContext& ctx)
+{
+  SimState st;
+  {
+    std::lock_guard<std::mutex> lk(ctx.state_mtx);
+    st = ctx.state;
+  }
+
+  std::cout
+    << "hb_state=" << (int)st.hb_state
+    << " hb_errors=" << (int)st.hb_errors
+    << " hb_mode=" << (int)st.hb_mode
+    << " | estop_active=" << (int)st.estop_active
+    << " source=" << (int)st.estop_source
+    << " dist_mm=" << st.estop_mm
+    << " reason=" << (int)st.estop_reason
+    << " | rpm=" << st.rpm
+    << " pulses=" << st.pulses
+    << " dir=" << (int)st.direction
+    << " | tof_mm=" << st.tof_mm
+    << " zone=" << (int)st.tof_zone
+    << " targets=" << (int)st.tof_count
+    << " | env=" << st.env_temp_c << "C " << st.env_humidity << "% " << st.env_light_lux << "lux " << st.env_pressure_hpa << "hPa"
+    << " | batt_mv=" << st.batt_mv << " soc=" << (int)st.batt_soc
+    << " | motor thr=" << (int)st.motor_throttle << " steer=" << (int)st.motor_steering
+    << "\n";
+}
+
+void cmd_reset(AppContext& ctx)
+{
+  {
+    std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+    ctx.state = ctx.defaults;
+  }
+  std::cout << "[OK] State reset to defaults\n";
+}
+
+void cmd_reload(AppContext& ctx)
+{
+  try {
+    ctx.scenarios = load_scenarios_dir(ctx.scenario_dir);
+    std::cout << "[OK] Reloaded scenarios (" << ctx.scenarios.size() << ") from " << ctx.scenario_dir << "\n";
+  } catch (const std::exception& e) {
+    std::cout << "[ERR] " << e.what() << "\n";
+  }
+}
+
+void cli_loop(AppContext& ctx)
+{
+  print_help();
+  std::string line;
+
+  // Main CLI loop
+  while (ctx.running.load()) {
+    // Prompt
+    std::cout << "emu> " << std::flush;
+    // Read line
+    if (!std::getline(std::cin, line)) {
+      ctx.running.store(false);
+      break;
+    }
+
+    // Trim and skip empty
+    line = trim(line);
+    if (line.empty()) continue;
+
+    // Parse command
+    std::istringstream iss(line);
+    std::string cmd;
+    iss >> cmd;
+
+    // Handle commands
+    if (cmd == "help") print_help();
+    else if (cmd == "list") cmd_list(ctx);
+    else if (cmd == "play") {
+      std::string arg; iss >> arg;
+      if (arg.empty()) {
+        std::cout << "usage: play <index|name>\n";
+      }
+      else cmd_play(arg, ctx);
+    }
+    else if (cmd == "stop") cmd_stop(ctx);
+    else if (cmd == "loop") {
+      std::string arg; iss >> arg;
+      if (arg.empty()) std::cout << "usage: loop on|off\n";
+      else cmd_loop(arg, ctx);
+    }
+    else if (cmd == "status") cmd_status(ctx);
+    else if (cmd == "show") cmd_show(ctx);
+    else if (cmd == "reset") cmd_reset(ctx);
+    else if (cmd == "reload") cmd_reload(ctx);
+    else if (cmd == "quit" || cmd == "exit") {
+      ctx.running.store(false);
+      break;
+    }
+    else {
+      std::cout << "Unknown command. Type 'help'.\n";
+    }
+  }
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/frames_builder.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/frames_builder.cpp
@@ -1,0 +1,134 @@
+#include "../inc/frames_builder.hpp"
+
+// -----------------------------
+// Build frames from SimState using can_id.h structs
+// -----------------------------
+WheelSpeed_t make_wheel(const SimState& st)
+{
+  WheelSpeed_t w{};
+  w.rpm          = st.rpm;
+  w.total_pulses = st.pulses;
+  w.direction    = st.direction;
+  w.status       = st.wheel_status;
+  return w;
+}
+
+Heartbeat_t make_hb(const SimState& st, uint32_t uptime_ms)
+{
+  Heartbeat_t h{};
+  h.state     = st.hb_state;
+  h.uptime_ms = uptime_ms;
+  h.errors    = st.hb_errors;
+  h.mode      = st.hb_mode;
+  h.crc       = 0;
+  h.crc       = crc8(reinterpret_cast<const uint8_t*>(&h), sizeof(h) - 1);
+  return h;
+}
+
+Environment_t make_env(const SimState& st)
+{
+  Environment_t e{};
+  const long temp_x100 = std::lround(st.env_temp_c * 100.0f);
+  e.temperature = clamp_i16(temp_x100);
+
+  float hum = st.env_humidity;
+  if (hum < 0.0f) hum = 0.0f;
+  if (hum > 100.0f) hum = 100.0f;
+  e.humidity = static_cast<uint8_t>(std::lround(hum));
+
+  uint32_t amb = st.env_light_lux / 100U;
+  if (amb > 255U) amb = 255U;
+  e.ambient_light_x100 = static_cast<uint8_t>(amb);
+
+  const uint32_t pressure_pa = static_cast<uint32_t>(std::lround(st.env_pressure_hpa * 100.0f)); // hPa -> Pa
+  e.pressure = (pressure_pa & 0xFFFFFFu);
+
+  e.status = st.env_status;
+  return e;
+}
+
+BatteryStatus_t make_batt(const SimState& st)
+{
+  BatteryStatus_t b{};
+  b.voltage_mv  = st.batt_mv;
+  b.current_ma  = st.batt_ma;
+  b.soc         = st.batt_soc;
+  b.temperature = st.batt_temp_c;
+  b.cycles      = st.batt_cycles;
+  b.status      = st.batt_status;
+  return b;
+}
+
+ImuAccel_t make_accel(const SimState& st)
+{
+  ImuAccel_t a{};
+  a.acc_x = clamp_i16(std::lround(st.acc_gx * 1000.0f));
+  a.acc_y = clamp_i16(std::lround(st.acc_gy * 1000.0f));
+  a.acc_z = clamp_i16(std::lround(st.acc_gz * 1000.0f));
+  a.reserved = 0;
+  a.status   = st.imu_status;
+  return a;
+}
+
+ImuGyro_t make_gyro(const SimState& st)
+{
+  ImuGyro_t g{};
+  g.gyro_x = clamp_i16(std::lround(st.gyro_dpsx * 10.0f));
+  g.gyro_y = clamp_i16(std::lround(st.gyro_dpsy * 10.0f));
+  g.gyro_z = clamp_i16(std::lround(st.gyro_dpsz * 10.0f));
+  g.reserved = 0;
+  g.status   = st.imu_status;
+  return g;
+}
+
+ImuMag_t make_mag(const SimState& st)
+{
+  ImuMag_t m{};
+  m.mag_x = clamp_i16(std::lround(st.mag_mgx));
+  m.mag_y = clamp_i16(std::lround(st.mag_mgy));
+  m.mag_z = clamp_i16(std::lround(st.mag_mgz));
+  m.reserved = 0;
+  m.status   = st.imu_status;
+  return m;
+}
+
+ToFDistance_t make_tof(const SimState& st)
+{
+  ToFDistance_t t{};
+  t.min_distance_mm = st.tof_mm;
+  t.nearest_zone    = st.tof_zone;
+  t.target_status   = st.tof_target_status;
+  t.detection_count = st.tof_count;
+  t.reserved[0] = 0;
+  t.reserved[1] = 0;
+  t.status = st.tof_status;
+  return t;
+}
+
+EmergencyStop_t make_estop(const SimState& st)
+{
+  EmergencyStop_t e{};
+  e.active      = st.estop_active;
+  e.source      = st.estop_source;
+  e.distance_mm = st.estop_mm;
+  e.reason      = st.estop_reason;
+  e.reserved[0] = 0;
+  e.reserved[1] = 0;
+  e.crc         = 0;
+  e.crc         = crc8(reinterpret_cast<const uint8_t*>(&e), sizeof(e) - 1);
+  return e;
+}
+
+MotorStatus_t make_motor_status(const SimState& st, uint8_t counter)
+{
+  MotorStatus_t m{};
+  m.actual_throttle  = st.motor_throttle;
+  m.actual_steering  = st.motor_steering;
+  m.motor_current_ma = st.motor_current_ma;
+  m.driver_temp      = st.motor_driver_temp;
+  m.pwm_duty         = st.motor_pwm;
+  m.counter          = counter;
+  m.crc              = 0;
+  m.crc              = crc8(reinterpret_cast<const uint8_t*>(&m), sizeof(m) - 1);
+  return m;
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/helpers.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/helpers.cpp
@@ -1,0 +1,119 @@
+#include "../inc/helpers.hpp"
+
+uint8_t crc8(const uint8_t* data, size_t len)
+{
+  uint8_t crc = 0x00;
+  for (size_t i = 0; i < len; ++i) {
+    crc ^= data[i];
+    for (int b = 0; b < 8; ++b) {
+      if (crc & 0x80) crc = static_cast<uint8_t>((crc << 1) ^ 0x07);
+      else           crc = static_cast<uint8_t>(crc << 1);
+    }
+  }
+  return crc;
+}
+
+uint64_t now_ms()
+{
+  using namespace std::chrono;
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+int16_t clamp_i16(long v) {
+  if (v > 32767) return 32767;
+  if (v < -32768) return -32768;
+  return static_cast<int16_t>(v);
+}
+uint8_t clamp_u8(long v) {
+  if (v < 0) return 0;
+  if (v > 255) return 255;
+  return static_cast<uint8_t>(v);
+}
+
+std::string trim(const std::string& s)
+{
+  size_t b = 0;
+  while (b < s.size() && std::isspace((unsigned char)s[b])) b++;
+  size_t e = s.size();
+  while (e > b && std::isspace((unsigned char)s[e-1])) e--;
+  return s.substr(b, e-b);
+}
+
+bool split_kv(const std::string& token, std::string& k, std::string& v)
+{
+  const size_t eq = token.find('=');
+  if (eq == std::string::npos) return false;
+  k = trim(token.substr(0, eq));
+  v = trim(token.substr(eq+1));
+  return !k.empty();
+}
+
+void apply_kv(SimState& st, const std::string& k, const std::string& v)
+{
+  auto to_l = [&](const std::string& s)->long { return std::strtol(s.c_str(), nullptr, 10); };
+  auto to_ul = [&](const std::string& s)->unsigned long { return std::strtoul(s.c_str(), nullptr, 10); };
+  auto to_f = [&](const std::string& s)->float { return std::strtof(s.c_str(), nullptr); };
+
+  // Heartbeat
+  if (k == "hb_state") st.hb_state = clamp_u8((long)to_ul(v));
+  else if (k == "hb_errors") st.hb_errors = clamp_u8((long)to_ul(v));
+  else if (k == "hb_mode") st.hb_mode = clamp_u8((long)to_ul(v));
+
+  // Emergency stop
+  else if (k == "estop_active") st.estop_active = (clamp_u8((long)to_ul(v)) ? 1 : 0);
+  else if (k == "estop_source") st.estop_source = clamp_u8((long)to_ul(v));
+  else if (k == "estop_mm") st.estop_mm = static_cast<uint16_t>(to_ul(v));
+  else if (k == "estop_reason") st.estop_reason = clamp_u8((long)to_ul(v));
+
+  // Wheel speed
+  else if (k == "rpm") st.rpm = clamp_i16(to_l(v));
+  else if (k == "pulses") st.pulses = static_cast<uint32_t>(to_ul(v));
+  else if (k == "direction") st.direction = clamp_u8((long)to_ul(v));
+  else if (k == "wheel_status") st.wheel_status = clamp_u8((long)to_ul(v));
+
+  // ToF
+  else if (k == "tof_mm") st.tof_mm = static_cast<uint16_t>(to_ul(v));
+  else if (k == "tof_zone") st.tof_zone = clamp_u8((long)to_ul(v));
+  else if (k == "tof_ts") st.tof_target_status = clamp_u8((long)to_ul(v));
+  else if (k == "tof_count") st.tof_count = clamp_u8((long)to_ul(v));
+  else if (k == "tof_status") st.tof_status = clamp_u8((long)to_ul(v));
+
+  // Environment
+  else if (k == "env_temp_c") st.env_temp_c = to_f(v);
+  else if (k == "env_humidity") st.env_humidity = to_f(v);
+  else if (k == "env_light_lux") st.env_light_lux = static_cast<uint32_t>(to_ul(v));
+  else if (k == "env_pressure_hpa") st.env_pressure_hpa = to_f(v);
+  else if (k == "env_status") st.env_status = clamp_u8((long)to_ul(v));
+
+  // Battery
+  else if (k == "batt_mv") st.batt_mv = static_cast<uint16_t>(to_ul(v));
+  else if (k == "batt_ma") st.batt_ma = clamp_i16(to_l(v));
+  else if (k == "batt_soc") st.batt_soc = clamp_u8((long)to_ul(v));
+  else if (k == "batt_temp_c") st.batt_temp_c = static_cast<int8_t>(to_l(v));
+  else if (k == "batt_cycles") st.batt_cycles = clamp_u8((long)to_ul(v));
+  else if (k == "batt_status") st.batt_status = clamp_u8((long)to_ul(v));
+
+  // IMU
+  else if (k == "acc_gx") st.acc_gx = to_f(v);
+  else if (k == "acc_gy") st.acc_gy = to_f(v);
+  else if (k == "acc_gz") st.acc_gz = to_f(v);
+  else if (k == "gyro_dpsx") st.gyro_dpsx = to_f(v);
+  else if (k == "gyro_dpsy") st.gyro_dpsy = to_f(v);
+  else if (k == "gyro_dpsz") st.gyro_dpsz = to_f(v);
+  else if (k == "mag_mgx") st.mag_mgx = to_f(v);
+  else if (k == "mag_mgy") st.mag_mgy = to_f(v);
+  else if (k == "mag_mgz") st.mag_mgz = to_f(v);
+  else if (k == "imu_status") st.imu_status = clamp_u8((long)to_ul(v));
+
+  // Motor status
+  else if (k == "motor_throttle") st.motor_throttle = static_cast<int8_t>(to_l(v));
+  else if (k == "motor_steering") st.motor_steering = static_cast<int8_t>(to_l(v));
+  else if (k == "motor_current_ma") st.motor_current_ma = static_cast<uint16_t>(to_ul(v));
+  else if (k == "motor_driver_temp") st.motor_driver_temp = static_cast<int8_t>(to_l(v));
+  else if (k == "motor_pwm") st.motor_pwm = clamp_u8((long)to_ul(v));
+
+  else {
+    std::cerr << "[EMU] Unknown key: " << k << "\n";
+  }
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/main.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/main.cpp
@@ -1,0 +1,173 @@
+// tools/can_sim/can_emulator.cpp
+//
+// Interactive CAN-only emulator that mimics STM32 publishing on SocketCAN.
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <chrono>
+#include <thread>
+#include <cmath>
+#include <mutex>
+#include <atomic>
+
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+
+#include "../../../inc/can_id.h"
+#include "../inc/helpers.hpp"
+#include "../inc/sim_state.hpp"
+#include "../inc/app_context.hpp"
+#include "../inc/can_sender.hpp"
+#include "../inc/scenario_loader.hpp"
+#include "../inc/frames_builder.hpp"
+#include "../inc/cli.hpp"
+
+// -----------------------------
+// Scenario player thread
+// -----------------------------
+static void scenario_player_loop(AppContext& ctx)
+{
+  while (ctx.running.load()) {
+    Playback pb;
+
+    {
+      std::lock_guard<std::mutex> lk(ctx.play_mtx);
+      pb = ctx.play;
+    }
+
+    // Check if we should be playing
+    // If not, sleep a bit and check again
+    if (!pb.playing || ctx.scenarios.empty() || pb.scenario_index >= ctx.scenarios.size()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      continue;
+    }
+
+    // Playing a scenario, get it
+    const Scenario& sc = ctx.scenarios[pb.scenario_index];
+
+    const uint64_t now = now_ms();
+    const uint32_t elapsed = static_cast<uint32_t>(now - pb.start_ms);
+
+    // Apply due events to ctx.state (under lock)
+    bool reached_end = false;
+    {
+      std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+
+      size_t i = pb.next_event_idx;
+      while (i < sc.events.size() && sc.events[i].t_ms <= elapsed) {
+        for (const auto& kv : sc.events[i].kv) apply_kv(ctx.state, kv.first, kv.second);
+        i++;
+      }
+      reached_end = (i >= sc.events.size());
+      // write back next_event_idx
+      {
+        std::lock_guard<std::mutex> lk_play(ctx.play_mtx);
+        // scenario might have changed; only write if still same one and playing
+        if (ctx.play.playing && ctx.play.scenario_index == pb.scenario_index) {
+          ctx.play.next_event_idx = i;
+        }
+      }
+    }
+
+    // handle end of scenario
+    if (reached_end) {
+      const uint32_t GRACE_MS = 1000;
+      if (elapsed >= sc.duration_ms + GRACE_MS) {
+        std::lock_guard<std::mutex> lk(ctx.play_mtx);
+        if (ctx.play.playing && ctx.play.scenario_index == pb.scenario_index) {
+          if (ctx.play.loop) {
+            ctx.play.start_ms = now_ms();
+            ctx.play.next_event_idx = 0;
+            // reset state to defaults + init
+            std::lock_guard<std::mutex> lk_state(ctx.state_mtx);
+            apply_scenario_start_locked(ctx, sc);
+          } else {
+            ctx.play.playing = false;
+          }
+        }
+      }
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+}
+
+static void usage(const char* prog)
+{
+  std::cerr
+    << "Usage:\n"
+    << "  " << prog << " <iface> <scenario_dir> [--p-wheel=MS] [--p-tof=MS] [--p-imu=MS] [--p-mag=MS] [--p-env=MS] [--p-batt=MS] [--p-hb=MS] [--p-motor=MS] [--p-estop=MS]\n";
+}
+
+int main(int argc, char** argv)
+{
+  if (argc != 1) {
+    usage(argv[0]);
+    return 1;
+  }
+
+  const std::string iface = "vcan0"; // default interface
+
+  AppContext ctx; // create context to hold shared state and config
+
+  // hardcoded scenario directory
+  ctx.scenario_dir = "./scenarios";
+
+  // load scenarios (fail if folder missing)
+  try {
+    ctx.scenarios = load_scenarios_dir(ctx.scenario_dir);
+  } catch (const std::exception& e) {
+    std::cerr << "[EMU] " << e.what() << "\n";
+    return 1;
+  }
+  if (ctx.scenarios.empty()) {
+    std::cerr << "[EMU] No scenarios found in: " << ctx.scenario_dir << "\n";
+    return 1;
+  }
+
+  std::cout << "[EMU] Loaded " << ctx.scenarios.size()
+            << " scenario(s) from " << ctx.scenario_dir << "\n";
+
+  std::cout << "[EMU] IDs (from can_id.h): wheel=0x" << std::hex << CAN_ID_WHEEL_SPEED
+            << " imu_acc=0x" << CAN_ID_IMU_ACCEL
+            << " imu_gyro=0x" << CAN_ID_IMU_GYRO
+            << " imu_mag=0x" << CAN_ID_IMU_MAG
+            << " env=0x" << CAN_ID_ENVIRONMENT
+            << " batt=0x" << CAN_ID_BATTERY
+            << " tof=0x" << CAN_ID_TOF_DISTANCE
+            << " hb=0x" << CAN_ID_HEARTBEAT_STM32
+            << " estop=0x" << CAN_ID_EMERGENCY_STOP
+            << " motor_status=0x" << CAN_ID_MOTOR_STATUS
+            << std::dec << "\n";
+
+  const int sock = open_can_tx_socket(iface);
+  if (sock < 0) return 1;
+
+  // Threads (IMPORTANT: pass ctx by reference using std::ref)
+  std::thread t_player(scenario_player_loop, std::ref(ctx));
+  std::thread t_sender(can_sender_loop, sock, std::ref(ctx));
+
+  // Main thread = CLI
+  cli_loop(ctx);
+
+  // Shutdown
+  ctx.running.store(false);
+  if (t_player.joinable()) t_player.join();
+  if (t_sender.joinable()) t_sender.join();
+
+  ::close(sock);
+  std::cout << "[EMU] Bye.\n";
+  return 0;
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/scenario_loader.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/scenario_loader.cpp
@@ -90,3 +90,15 @@ std::vector<Scenario> load_scenarios_dir(const std::string& dir)
 
   return out;
 }
+
+// Apply init + any t=0 events to current state (caller holds g_state_mtx)
+void apply_scenario_start_locked(AppContext& ctx, const Scenario& sc)
+{
+  ctx.state = ctx.defaults;
+  for (const auto& kv : sc.init_kv) apply_kv(ctx.state, kv.first, kv.second);
+  // Apply t=0 events
+  for (const auto& ev : sc.events) {
+    if (ev.t_ms != 0) break;
+    for (const auto& kv : ev.kv) apply_kv(ctx.state, kv.first, kv.second);
+  }
+}

--- a/src/kuksa/kuksa_RPi5/src/can_simulator/src/scenario_loader.cpp
+++ b/src/kuksa/kuksa_RPi5/src/can_simulator/src/scenario_loader.cpp
@@ -1,0 +1,92 @@
+#include "../inc/scenario_loader.hpp"
+
+Scenario load_scenario_file(const fs::path& p)
+{
+  Scenario sc;
+  sc.name = p.filename().string();
+  sc.path = p.string();
+
+  std::ifstream in(sc.path.c_str());
+  if (!in) throw std::runtime_error("Failed to open scenario: " + sc.path);
+
+  std::string line;
+  uint32_t ln = 0;
+
+  while (std::getline(in, line)) {
+    ln++;
+    line = trim(line);
+    if (line.empty() || line[0] == '#') continue;
+
+    // @init ...
+    if (line.rfind("@init", 0) == 0) {
+      std::istringstream iss(line.substr(5));
+      std::string tok;
+      while (iss >> tok) {
+        std::string k,v;
+        if (split_kv(tok, k, v)) sc.init_kv.push_back({k,v});
+      }
+      continue;
+    }
+
+    std::istringstream iss(line);
+    std::string tok;
+    Event ev;
+    bool has_t = false;
+
+    while (iss >> tok) {
+      std::string k, v;
+      if (!split_kv(tok, k, v)) continue;
+
+      if (k == "t" || k == "t_ms") {
+        ev.t_ms = static_cast<uint32_t>(std::strtoul(v.c_str(), nullptr, 10));
+        has_t = true;
+      } else {
+        ev.kv.push_back({k, v});
+      }
+    }
+
+    if (!has_t) {
+      std::cerr << "[EMU] " << sc.name << ": line " << ln << ": missing t=..., skipping\n";
+      continue;
+    }
+    sc.events.push_back(ev);
+  }
+
+  std::sort(sc.events.begin(), sc.events.end(),
+            [](const Event& a, const Event& b){ return a.t_ms < b.t_ms; });
+
+  if (!sc.events.empty()) sc.duration_ms = sc.events.back().t_ms;
+  return sc;
+}
+
+std::vector<Scenario> load_scenarios_dir(const std::string& dir)
+{
+  std::vector<Scenario> out;
+  fs::path root(dir);
+  if (!fs::exists(root)) throw std::runtime_error("Scenario dir does not exist: " + dir);
+  if (!fs::is_directory(root)) throw std::runtime_error("Not a directory: " + dir);
+
+  for (auto const& ent : fs::directory_iterator(root)) {
+    if (!ent.is_regular_file()) continue;
+    const fs::path p = ent.path();
+    const std::string ext = p.extension().string();
+    if (ext != ".txt" && ext != ".scn" && ext != ".scenario") continue;
+
+    try {
+      Scenario sc = load_scenario_file(p);
+      if (sc.events.empty() && sc.init_kv.empty()) {
+        std::cerr << "[EMU] Skipping empty scenario: " << sc.name << "\n";
+        continue;
+      }
+      out.push_back(sc);
+    } catch (const std::exception& e) {
+      std::cerr << "[EMU] Failed to load " << p.filename().string() << ": " << e.what() << "\n";
+    }
+  }
+
+  std::sort(out.begin(), out.end(), [](const Scenario& a, const Scenario& b){
+    return a.name < b.name;
+  });
+
+  return out;
+}


### PR DESCRIPTION
## 🧾 Summary
Explain what this PR does and why it’s needed:
This PR implements a CAN simulator that sends CAN frames without needing the hardware.

- [x] New Feature
- [ ] Bug Fix
- [x] Docs
- [ ] Refactor / Cleanup
- [ ] CI/CD

## 🔗 Related
#258 

## 🧪 Testing
How did you test it? Steps for reviewers to verify.

- [ ] Unit tests
- [ ] Hardware on PiRacer
- [x] Manual verification

**Steps to test:**
1. Build the emulator
cmake -S . -B build cmake --build build

2. Create and enable vcan0
`sudo modprobe vcan `
`sudo ip link add dev vcan0 type vcan `
`sudo ip link set up vcan0 `
`ip link show vcan0 `

3. Test that CAN works
`candump vcan0`

4. Run the emulator
./can_emulator

5. Run the can_to_kuksa_publisher with vcan0
./home/kuksa_RPi5/bin/can_to_kuksa_publisher vcan0

.6 Check if it is working with kuksa-client or Qt
kuksa-client --cacertificate /etc/kuksa/tls/ca.crt --token_or_tokenfile /etc/kuksa/jwt/publisher.jwt grpcs://10.21.220.191:55555

Then: getValue Vehicle.Speed

+ Run Qt and see the changes in the cluster
