### PR TITLE
fix - Added handler for srf08 sensor frame

### DIFF
--- a/src/kuksa/kuksa_RPi5/Makefile
+++ b/src/kuksa/kuksa_RPi5/Makefile
@@ -55,7 +55,8 @@ APP_SRCS := \
   $(SRC_DIR)/handlers/imu_magn.cpp \
   $(SRC_DIR)/handlers/emergency_stop.cpp \
   $(SRC_DIR)/handlers/battery.cpp \
-  $(SRC_DIR)/handlers/joystick.cpp
+  $(SRC_DIR)/handlers/joystick.cpp \
+  $(SRC_DIR)/handlers/srf08.cpp
 
 SRCS := $(APP_SRCS) $(GEN_SRCS)
 

--- a/src/kuksa/kuksa_RPi5/inc/can_id.h
+++ b/src/kuksa/kuksa_RPi5/inc/can_id.h
@@ -37,6 +37,7 @@
 #define CAN_ID_ENVIRONMENT      0x420
 #define CAN_ID_BATTERY          0x421
 #define CAN_ID_TOF_DISTANCE     0x422
+#define CAN_ID_SRF08_DISTANCE   0x423
 
 /* Joystick (temporary)*/
 #define CAN_ID_JOYSTICK			0x500

--- a/src/kuksa/kuksa_RPi5/inc/handlers.hpp
+++ b/src/kuksa/kuksa_RPi5/inc/handlers.hpp
@@ -22,3 +22,4 @@ void handleEmergencyStop(const can_frame& frame, IKuksaClient& kuksa);
 void handleJoystick(const can_frame& frame, IKuksaClient& kuksa);
 
 void handleAEB(const can_frame& frame, IKuksaClient& kuksa);
+void handleSrf08(const can_frame& frame, IKuksaClient& kuksa);

--- a/src/kuksa/kuksa_RPi5/src/dispatch_frames.cpp
+++ b/src/kuksa/kuksa_RPi5/src/dispatch_frames.cpp
@@ -21,6 +21,8 @@ static const Entry kHandlers[] = {
     { CAN_ID_JOYSTICK,         &handleJoystick },
 
     { CAN_ID_AEB_STOP,         &handleAEB },
+
+    { CAN_ID_SRF08_DISTANCE,   &handleSrf08 },
 };
 
 static const std::size_t kHandlersCount = sizeof(kHandlers) / sizeof(kHandlers[0]);

--- a/src/kuksa/kuksa_RPi5/src/handlers/srf08.cpp
+++ b/src/kuksa/kuksa_RPi5/src/handlers/srf08.cpp
@@ -1,0 +1,21 @@
+#include "../../inc/handlers.hpp"
+#include "../../inc/can_decode.hpp"
+#include "../../inc/interface_kuksa_client.hpp"
+#include "../../inc/signals.hpp"
+
+void handleSrf08(const can_frame& frame, IKuksaClient& kuksa)
+{
+    if (frame.can_dlc < 8)
+        return;
+
+    const std::uint16_t dist_mm    = can_decode::u16_le(&frame.data[0]);
+    const std::uint8_t  light      = can_decode::u8(&frame.data[2]);
+    const std::uint8_t  status     = can_decode::u8(&frame.data[7]);
+
+    // Only publish if sensor reports a valid reading (bit 0 set)
+    if (!(status & 0x01))
+        return;
+
+    kuksa.publishFloat(sig::ADAS_FRONT_DISTANCE_MM, static_cast<float>(dist_mm));
+    kuksa.publishFloat(sig::EXT_LIGHT_INTENSITY,    static_cast<float>(light));
+}

--- a/src/kuksa/kuksa_RPi5/vss.json
+++ b/src/kuksa/kuksa_RPi5/vss.json
@@ -62,7 +62,7 @@
         "datatype": "double",
         "description": "Vehicle speed measured by Hall effect sensor.",
         "type": "sensor",
-        "unit": "m/h",
+        "unit": "km/h",
         "min": 0,
         "comment": "Hall effect speed sensor via STM32 B-U585I-IOT02A"
       },
@@ -239,7 +239,7 @@
             "type": "branch",
             "children": {
               "PedalPosition": {
-                "datatype": "uint32",
+                "datatype": "uint8",
                 "description": "Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed.",
                 "max": 100,
                 "min": 0,
@@ -266,7 +266,7 @@
                 "type": "actuator"
               },
               "Front": {
-                "description": "Front obstacle detection zone.",
+                "description": "Front obstacle detection zone (SRF08 ultrasonic).",
                 "type": "branch",
                 "children": {
                   "IsWarning": {
@@ -276,12 +276,39 @@
                   },
                   "Distance": {
                     "datatype": "float",
-                    "description": "Distance to nearest obstacle.",
+                    "description": "Distance to nearest front obstacle.",
                     "type": "sensor",
                     "unit": "mm",
                     "min": 0,
-                    "max": 40000,
+                    "max": 6000,
+                    "comment": "SRF08 ultrasonic sensor via STM32"
+                  },
+                  "IsBraking": {
+                    "datatype": "boolean",
+                    "description": "Indicates if AEB is actively braking due to a front obstacle.",
+                    "type": "sensor",
+                    "comment": "Set by AEB task on STM32"
+                  }
+                }
+              },
+              "Up": {
+                "description": "Upward obstacle detection zone (VL53L5CX ToF).",
+                "type": "branch",
+                "children": {
+                  "Distance": {
+                    "datatype": "float",
+                    "description": "Distance to nearest obstacle above the vehicle.",
+                    "type": "sensor",
+                    "unit": "mm",
+                    "min": 0,
+                    "max": 4000,
                     "comment": "VL53L5CX ToF sensor (4x4 zone) via STM32"
+                  },
+                  "IsOnTop": {
+                    "datatype": "boolean",
+                    "description": "Indicates if an obstacle is detected within warning range above the vehicle.",
+                    "type": "sensor",
+                    "comment": "VL53L5CX ToF sensor via STM32"
                   }
                 }
               }


### PR DESCRIPTION
## 🧾 Summary
Explain what this PR does and why it’s needed:
This PR implements the addition of a frame handler for srf08 can frames.

- [ ] New Feature
- [x] Fix
- [ ] Docs
- [ ] Refactor / Cleanup
- [ ] CI/CD

**Steps to test:**
1. Check if the kuksa service is running on the RPi5
2. ```kuksa-client --cacertificate /etc/kuksa/tls/ca.crt --token_or_tokenfile /etc/kuksa/jwt/publisher.jwt grpcs://10.21.220.191:55555```
3. ```getValue Vehicle.ADAS.ObstacleDetection.Front.Distance```
4. Verify that a valid value is reaching the databroker
